### PR TITLE
Change README example tabs to ruby style 2 spaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,41 +48,41 @@ require 'async'
 require 'async/tcp_socket'
 
 def echo_server
-	Async::Reactor.run do |task|
-		# This is a synchronous block within the current task:
-		task.with(TCPServer.new('localhost', 9000)) do |server|
-			
-			# This is an asynchronous block within the current reactor:
-			task.reactor.with(server.accept) do |client|
-				data = client.read(512)
-				
-				task.sleep(rand)
-				
-				client.write(data)
-			end while true
-		end
-	end
+  Async::Reactor.run do |task|
+    # This is a synchronous block within the current task:
+    task.with(TCPServer.new('localhost', 9000)) do |server|
+      
+      # This is an asynchronous block within the current reactor:
+      task.reactor.with(server.accept) do |client|
+        data = client.read(512)
+        
+        task.sleep(rand)
+        
+        client.write(data)
+      end while true
+    end
+  end
 end
 
 def echo_client(data)
-	Async::Reactor.run do |task|
-		Async::TCPServer.connect('localhost', 9000) do |socket|
-			socket.write(data)
-			puts "echo_client: #{socket.read(512)}"
-		end
-	end
+  Async::Reactor.run do |task|
+    Async::TCPServer.connect('localhost', 9000) do |socket|
+      socket.write(data)
+      puts "echo_client: #{socket.read(512)}"
+    end
+  end
 end
 
 Async::Reactor.run do
-	# Start the echo server:
-	server = echo_server
-	
-	5.times.collect do |i|
-		echo_client("Hello World #{i}")
-	end.each(&:wait) # Wait until all clients are finished.
-	
-	# Terminate the server and all tasks created within it's async scope:
-	server.stop
+  # Start the echo server:
+  server = echo_server
+  
+  5.times.collect do |i|
+    echo_client("Hello World #{i}")
+  end.each(&:wait) # Wait until all clients are finished.
+  
+  # Terminate the server and all tasks created within it's async scope:
+  server.stop
 end
 ```
 


### PR DESCRIPTION
Love this project.

I'm going over some stuff to help you out. First thing that I noticed whilst going over the readme was the tabs in the example.

Kind of a small change, but I think it makes the example in the readme as displayed on GitHub much cleaner by using a ruby style 2 spaces for tabs.