### PR TITLE
Fix bug in argument passing

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -113,7 +113,7 @@ module Async
 		def run(*args)
 			if @status == :initialized
 				@status = :running
-				@fiber.resume(*args)
+				@fiber.resume(args)
 			else
 				raise RuntimeError, "Task already running!"
 			end

--- a/spec/async/reactor_spec.rb
+++ b/spec/async/reactor_spec.rb
@@ -76,6 +76,14 @@ RSpec.describe Async::Reactor do
 				expect(arg).to be == :arg
 			end.wait
 		end
+		
+		it "passes in the correct number of arguments" do
+			reactor.async(:arg1, :arg2, :arg3) do |task, arg1, arg2, arg3|
+				expect(arg1).to be == :arg1
+				expect(arg2).to be == :arg2
+				expect(arg3).to be == :arg3
+			end.wait
+		end
 	end
 	
 	describe '#to_s' do


### PR DESCRIPTION
Because the Fiber block does not use splat:

```
@fiber = Fiber.new do |args|
...
end
```

only one argument was being passed from the `#run` method in the call to
`@fiber.resume(*args)`. This fixes the issue by removing the splat from
the call to `resume`. This could also be fixed by adding a splat to the
block parameter. I chose this method under the assumption that it will
be faster by skipping the parameterization step when it's not necessary,
but adding the splat to the block parameter might be more consistent
with the rest of the code.
