### PR TITLE
Warn user that closing selector may cause IO leak

### DIFF
--- a/lib/async/debug/selector.rb
+++ b/lib/async/debug/selector.rb
@@ -67,7 +67,7 @@ module Async
 			
 			def close
 				if @monitors.any?
-					raise RuntimeError, "Trying to close selector with active monitors: #{@monitors.values.inspect}!"
+					raise RuntimeError, "Trying to close selector with active monitors: #{@monitors.values.inspect}! This may cause your socket or file descriptor to leak."
 				end
 			ensure
 				@selector.close

--- a/lib/async/debug/selector.rb
+++ b/lib/async/debug/selector.rb
@@ -25,6 +25,12 @@ require 'nio'
 
 module Async
 	module Debug
+		class LeakError < RuntimeError
+			def initialize(wrappers)
+				super "Trying to close selector with active monitors: #{wrappers.inspect}! This may cause your socket or file descriptor to leak."
+			end
+		end
+
 		class Selector
 			def initialize(selector = NIO::Selector.new)
 				@selector = selector
@@ -67,7 +73,7 @@ module Async
 			
 			def close
 				if @monitors.any?
-					raise RuntimeError, "Trying to close selector with active monitors: #{@monitors.values.inspect}! This may cause your socket or file descriptor to leak."
+					raise LeakError
 				end
 			ensure
 				@selector.close

--- a/lib/async/debug/selector.rb
+++ b/lib/async/debug/selector.rb
@@ -73,7 +73,7 @@ module Async
 			
 			def close
 				if @monitors.any?
-					raise LeakError
+					raise LeakError, @monitors.values
 				end
 			ensure
 				@selector.close


### PR DESCRIPTION
Gives the user a hint that closing a selector with active monitors may cause their socket or file descriptor to leak.  

Do you think a specific error like `LeakError` should be added?  If so, where would you define it?