### PR TITLE
Unblock fibers in order when waiting for enqueue on LimitedQueue

### DIFF
--- a/lib/async/queue.rb
+++ b/lib/async/queue.rb
@@ -51,7 +51,7 @@ module Async
 			super()
 			
 			@limit = limit
-			@full = Async::Condition.new
+			@full = Async::Queue.new
 		end
 		
 		attr :limit
@@ -63,7 +63,7 @@ module Async
 		
 		def enqueue item
 			if limited?
-				@full.wait
+				@full.dequeue
 			end
 			
 			super
@@ -72,7 +72,7 @@ module Async
 		def dequeue
 			item = super
 			
-			@full.signal unless @full.empty?
+			@full.enqueue(nil) unless @full.empty?
 			
 			return item
 		end

--- a/spec/async/queue_spec.rb
+++ b/spec/async/queue_spec.rb
@@ -53,4 +53,25 @@ RSpec.describe Async::LimitedQueue do
 		subject.enqueue(10)
 		expect(subject).to be_limited
 	end
+
+	it 'should resume waiting tasks in order' do
+		total_resumed = 0
+		total_dequeued = 0
+		Async do |producer|
+			10.times do
+				producer.async do
+					subject.enqueue('foo')
+					total_resumed += 1
+				end
+			end
+		end
+		Async do |consumer|
+			10.times do
+				subject.dequeue
+				total_dequeued += 1
+
+				expect(total_resumed).to be == total_dequeued
+			end
+		end
+	end
 end


### PR DESCRIPTION
First, just wanted to say this is an amazing library!

I was playing with LimitedQueue and I was surprised when I tried to enqueue stuff from multiple tasks they would all get resumed on my first dequeue. I was expecting the enqueuing tasks to be resumed in the order they invoked enqueue.

Now possibly this is mismatched expectations as I was trying to use this Queue with multiple producers. If this isn't the intention and this library only wants to support single producer-consumer use cases then we can close this PR.

The fix summary: I added an inner queue to the `LimitedQueue` that works in reverse to the outer queue; a producer attempts to dequeue from the inner queue if the limit has been reached and a consumer will push nil items to the queue which frees up the first producer.

I suspect this is too heavy-weight of a tool to use for this and I only chose it because the Queue guarantees order. If a semaphore or other similar primitive is better suited let me know!