### PR TITLE
Allow `task.logger=`.

### DIFF
--- a/lib/async/reactor.rb
+++ b/lib/async/reactor.rb
@@ -75,6 +75,10 @@ module Async
 			@logger || Event::Console.logger
 		end
 		
+		def logger=
+			@logger = logger
+		end
+		
 		def to_s
 			"<#{self.description} stopped=#{@stopped}>"
 		end

--- a/lib/async/reactor.rb
+++ b/lib/async/reactor.rb
@@ -72,11 +72,7 @@ module Async
 		end
 		
 		def logger
-			@logger || Event::Console.logger
-		end
-		
-		def logger=
-			@logger = logger
+			@logger ||= Event::Console.logger
 		end
 		
 		def to_s

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -76,11 +76,7 @@ module Async
 		end
 		
 		def logger
-			@logger || @parent&.logger
-		end
-		
-		def logger=
-			@logger = logger
+			@logger ||= @parent&.logger
 		end
 		
 		# @attr ios [Reactor] The reactor the task was created within.
@@ -109,8 +105,8 @@ module Async
 			end
 		end
 		
-		def async(*args, &block)
-			task = Task.new(@reactor, self, &block)
+		def async(*args, **options, &block)
+			task = Task.new(@reactor, self, **options, &block)
 			
 			task.run(*args)
 			
@@ -190,9 +186,9 @@ module Async
 				raise
 			elsif @finished.nil?
 				# If no one has called wait, we log this as an error:
-				Async.logger.error(self) {$!}
+				logger.error(self) {$!}
 			else
-				Async.logger.debug(self) {$!}
+				logger.debug(self) {$!}
 			end
 		end
 		
@@ -207,7 +203,7 @@ module Async
 				begin
 					@result = yield(self, *args)
 					@status = :complete
-					# Async.logger.debug("Task #{self} completed normally.")
+					# logger.debug("Task #{self} completed normally.")
 				rescue Stop
 					stop!
 				rescue StandardError => error
@@ -215,7 +211,7 @@ module Async
 				rescue Exception => exception
 					fail!(exception, true)
 				ensure
-					# Async.logger.debug("Task #{self} closing: #{$!}")
+					# logger.debug("Task #{self} closing: #{$!}")
 					finish!
 				end
 			end

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -76,7 +76,11 @@ module Async
 		end
 		
 		def logger
-			@logger ||= @parent.logger
+			@logger || @parent&.logger
+		end
+		
+		def logger=
+			@logger = logger
 		end
 		
 		# @attr ios [Reactor] The reactor the task was created within.

--- a/spec/async/logger_spec.rb
+++ b/spec/async/logger_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe 'Async.logger' do
 		Async(logger: logger) do |task|
 			expect(task.logger).to be == logger
 			logger.warn message
-		end
+		end.wait
 		
 		expect(capture.events.last).to include({
 			severity: :warn,
@@ -43,12 +43,11 @@ RSpec.describe 'Async.logger' do
 	end
 	
 	it "can change nested logger" do
-		Async(logger: logger) do |task|
-			expect(task.logger).to be == logger
-			
-			task.logger = nil
-			expect(task.logger).to be == task.reactor.logger
-		end
+		Async do |parent|
+			parent.async(logger: logger) do |task|
+				expect(task.logger).to be == logger
+			end.wait
+		end.wait
 	end
 	
 	it "can use parent logger" do
@@ -57,11 +56,6 @@ RSpec.describe 'Async.logger' do
 			
 			expect(parent.logger).to be == logger
 			expect(child.logger).to be == logger
-			
-			parent.logger = nil
-			
-			expect(parent.logger).to be == parent.reactor.logger
-			expect(child.logger).to be == parent.reactor.logger
-		end
+		end.wait
 	end
 end


### PR DESCRIPTION
Related discussions:

- https://github.com/socketry/rubydns/issues/42
- https://github.com/socketry/event/issues/3

The main point is should user be able to change `task.logger`?

Because `Task.logger` is defined as:

```ruby
		def logger
			@logger || @parent&.logger
		end
```

If `parent.logger` is changed, the child logger will automatically use it.

A more efficient approach is:

```ruby
		def logger
			@logger ||= @parent&.logger
		end
```

This will cache the logger, but it won't be correct of the parent logger is changed after the child is created. It's more efficient after first invocation but the semantics are wrong if we also want to support `task.logger=`.

One alternative to `task.logger=` is to make a nested child task. It's a little bit heavy, but it might make things simpler.

e.g.

```ruby
endpoint.accept do |peer, task|
  task.async(logger: RequestLogger.new(task.logger, peer)) do
    # Process request here
  end.wait
end
```

Feedback welcome @bryanp 