### PR TITLE
Implement before- and after-fiber-creation hooks.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -249,8 +249,10 @@ module Async
 		end
 		
 		def make_fiber(&block)
+			payloads = reactor.call_before_hooks
 			Fiber.new do |*arguments|
 				set!
+				reactor.call_after_hooks(payloads)
 				
 				begin
 					@result = yield(self, *arguments)


### PR DESCRIPTION
PR for discussion:

Web apps sometimes store per-request state in a thread-local variable, e.g. using the [request_store gem](https://github.com/steveklabnik/request_store). If a server spawns multiple fibers while handling a request, the fibers won't have access to the thread-local storage of the original fiber.

This PR has a possible solution: give clients the ability to insert one or more hooks before and after fiber creation. Each `before_create` hook is called in the parent fiber and returns a payload. The paired `after_create` hook is called in the new child fiber and is passed in the payload that `before_create` returned.

This enables passing thread-local storage into a task:

    Async::Reactor.hook(
      before_create: -> { Thread.current[:store] }),
      after_create: ->(store) { Thread.current[:store] = store.dup }
    )

(For this to work with `request_store` I could make  PR to add a `replace!(store)` method that replaces the thread-local variable with the store that's passed in.)

There's one potentially large flaw in this approach that is open for discussion: the way I wrote it, the `hook` method can only be called once you're already inside a reactor loop. This makes it impossible for a web app to have an initialization phase at startup that sets up all the hooks, but I think that would be an easier way to use an interface like this. And web apps with Falcon don't own the outer reactor loop, so they can't just write an outer `Async do` followed by a setting up the hooks, as I did in the specs.