### PR TITLE
Add a Node#hierarchy method for flexible accounting.

### DIFF
--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -23,6 +23,12 @@ require 'set'
 module Async
 	# Represents a node in a tree, used for nested {Task} instances.
 	class Node
+		HIERARCHY_FORMAT = ->(node, level) { {level: level, node: node} }
+		private_constant :HIERARCHY_FORMAT
+		
+		HIERARCHY_PRINT_FORMAT = ->(node, level) { "#{"\t" * level}#{node}" }
+		private_constant :HIERARCHY_PRINT_FORMAT
+		
 		# Create a new node in the tree.
 		# @param parent [Node, nil] This node will attach to the given parent.
 		def initialize(parent = nil)
@@ -136,10 +142,16 @@ module Async
 			@children&.each(&:stop)
 		end
 		
-		def print_hierarchy(out = $stdout)
-			self.traverse do |node, level|
-				out.puts "#{"\t" * level}#{node}"
+		def hierarchy(out: [], reducer: :<<, format: HIERARCHY_FORMAT)
+			traverse do |node, level|
+				out.public_send reducer, format.call(node, level)
 			end
+			
+			out
+		end
+		
+		def print_hierarchy(out = $stdout)
+			hierarchy(out: out, reducer: :puts, format: HIERARCHY_PRINT_FORMAT)
 		end
 	end
 end

--- a/spec/async/node_spec.rb
+++ b/spec/async/node_spec.rb
@@ -61,6 +61,29 @@ RSpec.describe Async::Node do
 		end
 	end
 	
+	describe '#hierarchy' do
+		let!(:child) {Async::Node.new(subject)}
+		
+		it 'can list the hierarchy' do
+			list = subject.hierarchy
+			
+			expect(list.size).to be 2
+			expect(list).to be_a Array
+			
+			expect(list.dig(0, :node)).to be_a Async::Node
+			expect(list.dig(1, :node)).to be_a Async::Node
+		end
+		
+		it 'can use a collection other than Array' do
+			queue = subject.hierarchy(out: Async::Queue.new, reducer: :<<)
+			
+			expect(queue).to be_a Async::Queue
+			
+			expect(queue.dequeue.fetch(:node)).to be_a Async::Node
+			expect(queue.dequeue.fetch(:node)).to be_a Async::Node
+		end
+	end
+
 	describe '#consume' do
 		let(:middle) {Async::Node.new(subject)}
 		let(:bottom) {Async::Node.new(middle)}


### PR DESCRIPTION
This PR adds a Node#hierarchy for more flexibility with outputting hierarchy. I switched over Node#print_hierarchy to use the new method internally.

My hope was to make Node hierarchy discoverable via a mechanism other than printing.

For an example, here's a typical #print_hierarchy output.

```
#<Async::Node:0x000118>
	#<Async::Node:0x000078>
		#<Async::Node:0x0000a0>
			#<Async::Node:0x0000c8>
	#<Async::Node:0x0000f0>
```

And the corresponding current #hierarchy return value.

```ruby
[{:level=>0, :node=>#<Async::Node:0x000118>},
 {:level=>1, :node=>#<Async::Node:0x000078>},
 {:level=>2, :node=>#<Async::Node:0x0000a0>},
 {:level=>3, :node=>#<Async::Node:0x0000c8>},
 {:level=>1, :node=>#<Async::Node:0x0000f0>}]
```