### PR TITLE
Scheduler implementation

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -76,6 +76,16 @@ module Async
 			wrapper.reactor = nil
 		end
 		
+		# Wait for the specified process ID to exit.
+		# @parameter pid [Integer] The process ID to wait for.
+		# @parameter flags [Integer] A bit-mask of flags suitable for `Process::Status.wait`.
+		# @returns [Process::Status] A process status instance.
+		def process_wait(pid, flags)
+			Thread.new do
+				Process::Status.wait(pid, flags)
+			end.value
+		end
+		
 		def kernel_sleep(duration)
 			@reactor.sleep(duration)
 		end

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -1,0 +1,102 @@
+# Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require_relative 'clock'
+
+module Async
+	class Scheduler
+		if Fiber.respond_to?(:set_scheduler)
+			def self.supported?
+				true
+			end
+		else
+			def self.supported?
+				false
+			end
+		end
+		
+		def initialize(reactor)
+			@reactor = reactor
+			@wrappers = nil
+		end
+		
+		def set!
+			@wrappers = {}
+			Fiber.set_scheduler(self)
+		end
+		
+		def clear!
+			# Because these instances are created with `autoclose: false`, this does not close the underlying file descriptor:
+			# @ios&.each_value(&:close)
+			
+			@wrappers = nil
+			Fiber.set_scheduler(nil)
+		end
+		
+		private def from_io(io)
+			@wrappers[io] ||= Wrapper.new(io, @reactor)
+		end
+		
+		def io_wait(io, events, timeout = nil)
+			wrapper = from_io(io)
+			
+			if events == IO::READABLE
+				if wrapper.wait_readable(timeout)
+					return IO::READABLE
+				end
+			elsif events == IO::WRITABLE
+				if wrapper.wait_writable(timeout)
+					return IO::WRITABLE
+				end
+			else
+				if wrapper.wait_any(timeout)
+					return events
+				end
+			end
+			
+			return false
+		ensure
+			wrapper.reactor = nil
+		end
+		
+		def kernel_sleep(duration)
+			@reactor.sleep(duration)
+		end
+		
+		def block(blocker, timeout)
+			@reactor.block(blocker, timeout)
+		end
+		
+		def unblock(blocker, fiber)
+			@reactor.unblock(blocker, fiber)
+		end
+		
+		def close
+		end
+		
+		def fiber(&block)
+			task = Task.new(&block)
+			
+			task.resume
+			
+			return task.fiber
+		end
+	end
+end

--- a/spec/async/scheduler_spec.rb
+++ b/spec/async/scheduler_spec.rb
@@ -1,0 +1,110 @@
+# Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'async/scheduler'
+require 'async/barrier'
+require 'net/http'
+
+RSpec.describe Async::Scheduler, if: Async::Scheduler.supported? do
+	include_context Async::RSpec::Reactor
+	
+	it "can intercept sleep" do
+		expect(reactor).to receive(:sleep).with(0.001)
+		
+		sleep(0.001)
+	end
+	
+	describe 'IO.pipe' do
+		let(:message) {"Helloooooo World!"}
+		
+		it "can send message via pipe" do
+			input, output = IO.pipe
+			
+			reactor.async do
+				sleep(0.001)
+				
+				message.each_char do |character|
+					output.write(character)
+				end
+				
+				output.close
+			end
+			
+			expect(input.read).to be == message
+			
+			input.close
+		end
+		
+		it "can fetch website using Net::HTTP" do
+			barrier = Async::Barrier.new
+			events = []
+			
+			3.times do |i|
+				barrier.async do
+					events << i
+					response = Net::HTTP.get(URI "https://www.codeotaku.com/index")
+					expect(response).to_not be_nil
+					events << i
+				end
+			end
+			
+			barrier.wait
+			
+			# The requests all get started concurrently:
+			expect(events.first(3)).to be == [0, 1, 2]
+		end
+	end
+	
+	context "with thread" do
+		let(:queue) {Thread::Queue.new}
+		subject {Thread.new{queue.pop}}
+		
+		it "can join thread" do
+			waiting = 0
+			
+			3.times do
+				Async do
+					waiting += 1
+					subject.join
+					waiting -= 1
+				end
+			end
+			
+			expect(waiting).to be == 3
+			queue.close
+		end
+	end
+	
+	context "with queue" do
+		subject {Thread::Queue.new}
+		let(:item) {"Hello World"}
+		
+		it "can pass items between thread and fiber" do
+			Async do
+				expect(subject.pop).to be == item
+			end
+			
+			Thread.new do
+				expect(Fiber).to be_blocking
+				subject.push(item)
+			end.join
+		end
+	end
+end

--- a/spec/async/scheduler_spec.rb
+++ b/spec/async/scheduler_spec.rb
@@ -31,6 +31,16 @@ RSpec.describe Async::Scheduler, if: Async::Scheduler.supported? do
 		sleep(0.001)
 	end
 	
+	describe 'Process.wait' do
+		it "can wait on child process" do
+			expect(reactor.scheduler).to receive(:process_wait).and_call_original
+			
+			pid = ::Process.spawn("true")
+			_, status = Process.wait2(pid)
+			expect(status).to be_success
+		end
+	end
+	
 	describe 'IO.pipe' do
 		let(:message) {"Helloooooo World!"}
 		

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require "covered/rspec"
+require 'async/rspec'
+require 'covered/rspec'
 
 if RUBY_PLATFORM =~ /darwin/
 	Q = 20


### PR DESCRIPTION
This is a prototype of the scheduler which uses the interface provided by https://github.com/ruby/ruby/pull/3032

At the present time, the scheduler is an optional set of hooks for implementing non-blocking IO. However, in the future, the scheduler might form the core of the reactor, replacing the selector entirely.