### PR TITLE
Make Kernel#Sync public

### DIFF
--- a/lib/async.rb
+++ b/lib/async.rb
@@ -25,6 +25,7 @@ require_relative "async/logger"
 require_relative "async/reactor"
 
 require_relative "kernel/async"
+require_relative "kernel/sync"
 
 module Async
 	# Invoke `Reactor.run` with all arguments/block.


### PR DESCRIPTION
Hello,

I'm not sure if it was intended to be public, but i would love to use `Sync` for some use cases. The one i encountered is that i need the value returned by a call to some `async-redis` function.

I often ends up doing this:

```ruby
value = Async { redis.llen 'list' }.wait
```

which is exactly what is provided by the `Kernel#Sync` method. Do you think that exposing this method could make sense?

Thank's for this awesome gem!