### PR TITLE
Use a linked list for children

### DIFF
--- a/spec/async/node_spec.rb
+++ b/spec/async/node_spec.rb
@@ -35,14 +35,14 @@ RSpec.describe Async::Node do
 			child.parent = nil
 			
 			expect(child.parent).to be_nil
-			expect(subject.children).to be_empty
+			expect(subject.children).to be_nil
 		end
 		
 		it "can consume bottom to top" do
 			child.consume
 			
 			expect(child.parent).to be_nil
-			expect(subject.children).to be_empty
+			expect(subject.children).to be_nil
 		end
 	end
 	
@@ -64,15 +64,33 @@ RSpec.describe Async::Node do
 	end
 	
 	describe '#consume' do
-		let(:middle) {Async::Node.new(subject)}
-		let(:bottom) {Async::Node.new(middle)}
-		
 		it "can't consume middle node" do
+			middle = Async::Node.new(subject)
+			bottom = Async::Node.new(middle)
+			
 			expect(bottom.parent).to be middle
 			
 			middle.consume
 			
 			expect(bottom.parent).to be middle
+		end
+		
+		it "can consume node while enumerating children" do
+			3.times do
+				Async::Node.new(subject)
+			end
+			
+			children = subject.children.each.to_a
+			expect(subject.children.size).to be 3
+			
+			enumerated = []
+			
+			subject.children.each do |child|
+				child.consume
+				enumerated << child
+			end
+			
+			expect(enumerated).to be == children
 		end
 	end
 	
@@ -129,9 +147,9 @@ RSpec.describe Async::Node do
 			
 			# subject -> middle -> child1 (transient)
 			#                   -> child2
-			middle = Async::Node.new(subject)
-			child1 = Async::Node.new(middle, transient: true)
-			child2 = Async::Node.new(middle)
+			middle = Async::Node.new(subject, annotation: "middle")
+			child1 = Async::Node.new(middle, transient: true, annotation: "child1")
+			child2 = Async::Node.new(middle, annotation: "child2")
 			
 			allow(child1).to receive(:finished?).and_return(false)
 			
@@ -169,7 +187,7 @@ RSpec.describe Async::Node do
 			expect(child.parent).to be_nil
 			expect(middle.parent).to be subject
 			expect(subject.children).to include(middle)
-			expect(middle.children).to be_empty
+			expect(middle.children).to be_nil
 		end
 	end
 end

--- a/spec/async/queue_spec.rb
+++ b/spec/async/queue_spec.rb
@@ -109,6 +109,7 @@ RSpec.describe Async::LimitedQueue do
 	it 'should resume waiting tasks in order' do
 		total_resumed = 0
 		total_dequeued = 0
+		
 		Async do |producer|
 			10.times do
 				producer.async do
@@ -117,13 +118,12 @@ RSpec.describe Async::LimitedQueue do
 				end
 			end
 		end
-		Async do |consumer|
-			10.times do
-				subject.dequeue
-				total_dequeued += 1
-
-				expect(total_resumed).to be == total_dequeued
-			end
+		
+		10.times do
+			item = subject.dequeue
+			total_dequeued += 1
+			
+			expect(total_resumed).to be == total_dequeued
 		end
 	end
 end

--- a/spec/async/reactor_spec.rb
+++ b/spec/async/reactor_spec.rb
@@ -80,17 +80,37 @@ RSpec.describe Async::Reactor do
 		end
 	end
 	
+	describe '#print_hierarchy' do
+		it "can print hierarchy" do
+			subject.async do |parent|
+				parent.async do |child|
+					child.sleep 1
+				end
+				
+				parent.sleep 1
+			end
+			
+			output = StringIO.new
+			subject.print_hierarchy(output)
+			lines = output.string.lines
+			
+			expect(lines[0]).to be =~ /#<Async::Reactor.*(running)/
+			expect(lines[1]).to be =~ /\t#<Async::Task.*(running)/
+			expect(lines[2]).to be =~ /\t\t#<Async::Task.*(running)/
+		end
+	end
+	
 	describe '#stop' do
 		it "can stop the reactor" do
 			state = nil
 			
-			subject.async do |task|
+			subject.async(annotation: "sleep(10)") do |task|
 				state = :started
 				task.sleep(10)
 				state = :stopped
 			end
 			
-			subject.async do |task|
+			subject.async(annotation: "reactor.stop") do |task|
 				task.sleep(0.1)
 				task.reactor.stop
 			end

--- a/spec/async/task_spec.rb
+++ b/spec/async/task_spec.rb
@@ -447,6 +447,16 @@ RSpec.describe Async::Task do
 		end
 	end
 	
+	describe '#children' do
+		it "enumerates children in same order they are created" do
+			tasks = 10.times.map do |i|
+				reactor.async(annotation: "Task #{i}") {|task| task.sleep(1)}
+			end
+			
+			expect(reactor.children.each.to_a).to be == tasks
+		end
+	end
+	
 	describe '#to_s' do
 		it "should show running" do
 			apples_task = reactor.async do |task|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require "covered/rspec"
 
 if RUBY_PLATFORM =~ /darwin/
-	Q = 10
+	Q = 20
 else
 	Q = 1
 end


### PR DESCRIPTION
Now that transient tasks can move up the tree, using a hash table (set) for the children nodes has become a problem. In particular, you cannot append to a hash table/set while enumerating it and the semantics of any such operation are not well defined. Using a linked list provides that definition.