### PR TITLE
Adds a method to DRY timer code a little bit

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -178,6 +178,17 @@ module Async
 			end
 		end
 		
+		# Syntactic sugar to create a timer.
+		def add_timer(interval: 0, periodic: true)
+			async do |subtask|
+				loop do
+					subtask.sleep(interval)
+					yield
+					break unless periodic
+				end
+			end
+		end
+
 		# Lookup the {Task} for the current fiber. Raise `RuntimeError` if none is available.
 		# @return [Async::Task]
 		# @raise [RuntimeError] if task was not {set!} for the current fiber.


### PR DESCRIPTION
Timers are simple to create with Async, but they require repeating an incantation of boilerplate for every timer that an app creates.

This method wraps that incantation so that instead of this:

```ruby
async do |timer_task|
  loop do
    timer_task.sleep DURATION # some number of seconds to wait between runs of the timer
   # Do Stuff Here
  end
end
```

One can do this:

```ruby
task.add_timer(DURATION) do
  # Do Stuff Here
end
```

It's a little cleaner to look at, and it's a little more clear when scanning the code what is happening.