### PR TITLE
Async::Task: don't forward #timeout to reactor

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -103,7 +103,7 @@ module Async
 		# @attr ios [Reactor] The reactor the task was created within.
 		attr :reactor
 		
-		def_delegators :@reactor, :with_timeout, :timeout, :sleep
+		def_delegators :@reactor, :with_timeout, :sleep
 		
 		# Yield back to the reactor and allow other fibers to execute.
 		def yield


### PR DESCRIPTION
As far as I can tell, `Async::Reactor` does not have a `#timeout` method.

## Types of Changes

- [X] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

- [ ] I added new tests for my changes.
- [X] I ran all the tests locally.
