### PR TITLE
ensure to use top IO module

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -57,13 +57,13 @@ module Async
 		def io_wait(io, events, timeout = nil)
 			wrapper = from_io(io)
 			
-			if events == IO::READABLE
+			if events == ::IO::READABLE
 				if wrapper.wait_readable(timeout)
-					return IO::READABLE
+					return ::IO::READABLE
 				end
-			elsif events == IO::WRITABLE
+			elsif events == ::IO::WRITABLE
 				if wrapper.wait_writable(timeout)
-					return IO::WRITABLE
+					return ::IO::WRITABLE
 				end
 			else
 				if wrapper.wait_any(timeout)


### PR DESCRIPTION
This fix an error when Rails 6.1 + Falcon + Ruby 3.0.0-dev

```
NameError (uninitialized constant Async::IO::READABLE
Did you mean?  Forwardable):

async (1.28.0) lib/async/scheduler.rb:60:in `io_wait'
```

some off-topic questions:

- It looks like async can't use 3rd fiber scheduler yet, if I'm wrong, how?
- It looks if current Ruby support fiber scheduler, `async` will auto set a `scheduler`, I'm concerning that may break Rails app because db drivers, redis drivers, etc. are not support fiber yet


## Types of Changes

- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

## Testing

- [ ] I added new tests for my changes.
- [ ] I ran all the tests locally.
