### PR TITLE
Fix Async::Scheduler#fiber hook

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -102,9 +102,9 @@ module Async
 		end
 		
 		def fiber(&block)
-			task = Task.new(&block)
+			task = Task.new(@reactor, &block)
 			
-			task.resume
+			task.run
 			
 			return task.fiber
 		end


### PR DESCRIPTION
The current implementation of `Async::Scheduler#fiber(&block)` causes `Fiber.schedule {}` to always fail. For example:

```ruby
require "async"

Async do
  Fiber.schedule { puts "hello" }
end
```

```
  0.0s    error: Async::Task [oid=0x3c] [pid=51] [2021-01-02 10:36:33 +0000]
               |   ArgumentError: wrong number of arguments (given 0, expected 1..2)
               |   → vendor/gems/3.0.0/gems/async-1.28.2/lib/async/task.rb:75 in `initialize'
               |     vendor/gems/3.0.0/gems/async-1.28.2/lib/async/scheduler.rb:105 in `new'
               |     vendor/gems/3.0.0/gems/async-1.28.2/lib/async/scheduler.rb:105 in `fiber'
               |     bug.rb:4 in `schedule'
               |     bug.rb:4 in `block in <main>'
               |     vendor/gems/3.0.0/gems/async-1.28.2/lib/async/task.rb:265 in `block in make_fiber'
```

## Types of Changes

- [x] Bug fix.
- [ ] New feature.
- [ ] Performance improvement.

This tiny patch fixes the calls to `Async::Task` and allows the usage of `Fiber.schedule` to create non blocking fibers.

## Testing

I tried to write a test, but I'm not knowledgeable enough with how the spec are written.