### PR TITLE
Async::Task#wait_all

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,3 +3,4 @@ root = true
 [*]
 indent_style = tab
 indent_size = 2
+trim_trailing_whitespace = false

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -156,6 +156,16 @@ module Async
 		# Deprecated.
 		alias result wait
 		# Soon to become attr :result
+
+		# Wait on all children to complete, including subtasks.
+		# @return [Object] the final expression/result of the task's block
+		def wait_all(task = self)
+			task.children&.each do |child|
+				wait_all(child)
+			end
+
+			task.wait
+		end
 		
 		# Stop the task and all of its children.
 		# @return [void]

--- a/spec/async/task_spec.rb
+++ b/spec/async/task_spec.rb
@@ -468,6 +468,52 @@ RSpec.describe Async::Task do
 			expect(innocent_task).to be_finished
 		end
 	end
+
+	describe '#wait_all' do
+		it "will wait on all subtasks to complete" do
+			result = nil
+
+			reactor.async do |task|
+				wait_task = task.async do |subtask1|
+					subtask1.async do |subtask2|
+						subtask2.async do |subtask3|
+							subtask3.sleep(0.25)
+
+							result = :subtask3
+						end
+					end
+				end
+
+				wait_task.wait_all
+			end
+
+			reactor.run
+
+			expect(result).to eq(:subtask3)
+		end
+
+		it "will return the result" do
+			result = nil
+
+			reactor.async do |task|
+				wait_task = task.async do |subtask1|
+					subtask1.async do |subtask2|
+						subtask2.async do |subtask3|
+							subtask3.sleep(0.25)
+						end
+					end
+
+					:subtask1
+				end
+
+				result = wait_task.wait_all
+			end
+
+			reactor.run
+
+			expect(result).to eq(:subtask1)
+		end
+	end
 	
 	describe '#children' do
 		it "enumerates children in same order they are created" do


### PR DESCRIPTION
<!--
  What changes are being made? What problem are you solving?
  What feature/bug is being fixed here?
  If this is an aesthetic change, please include screenshots.
-->

Provides a way to wait on all children, _including_ children and their tasks. This came out of a conversation I had with @ioquatix last week and is the approach I ended up moving forward with for my own use-case.

## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [x] I added new tests for my changes.
- [x] I ran all the tests locally.
