### PR TITLE
Expose task finished condition so that it can be created optimistically to avoid race on #wait.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -72,14 +72,14 @@ module Async
 		# Create a new task.
 		# @param reactor [Async::Reactor] the reactor this task will run within.
 		# @param parent [Async::Task] the parent task.
-		def initialize(reactor, parent = Task.current?, logger: nil, **options, &block)
+		def initialize(reactor, parent = Task.current?, logger: nil, finished: nil, **options, &block)
 			super(parent || reactor, **options)
 			
 			@reactor = reactor
 			
 			@status = :initialized
 			@result = nil
-			@finished = nil
+			@finished = finished
 			
 			@logger = logger
 			

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -28,7 +28,10 @@ module Kernel
 		if task = ::Async::Task.current?
 			yield task
 		else
-			::Async::Reactor.run(&block).wait
+			::Async::Reactor.run(
+				finished: ::Async::Condition.new,
+				&block
+			).wait
 		end
 	end
 end

--- a/spec/kernel/sync_spec.rb
+++ b/spec/kernel/sync_spec.rb
@@ -43,12 +43,22 @@ RSpec.describe Kernel do
 				result = Sync do |sync_task|
 					expect(Async::Task.current).to be task
 					expect(sync_task).to be task
-
+					
 					next value
 				end
 				
 				expect(result).to be == value
 			end
+		end
+		
+		it "can propagate error without logging them" do
+			expect(Console.logger).to_not receive(:error)
+			
+			expect do
+				Sync do
+					raise StandardError, "brain not provided"
+				end
+			end.to raise_exception(StandardError, /brain/)
 		end
 	end
 end


### PR DESCRIPTION
## Types of Changes

<!-- Put an `x` in all the boxes that apply: -->
- [x] Bug fix.
- [x] New feature.
- [ ] Performance improvement.

## Testing

<!-- Put an `x` in all the boxes that apply: -->
- [x] I added new tests for my changes.
- [x] I ran all the tests locally.
