### PR TITLE
Add Async::Semaphore#sync

### DIFF
--- a/lib/async/semaphore.rb
+++ b/lib/async/semaphore.rb
@@ -65,6 +65,16 @@ module Async
 			end
 		end
 		
+		def sync(*arguments)
+			acquire
+			
+			begin
+				yield Task.current, *arguments
+			ensure
+				release
+			end
+		end
+		
 		# Acquire the semaphore, block if we are at the limit.
 		# If no block is provided, you must call release manually.
 		# @yield when the semaphore can be acquired

--- a/spec/async/semaphore_spec.rb
+++ b/spec/async/semaphore_spec.rb
@@ -86,6 +86,25 @@ RSpec.describe Async::Semaphore do
 		end
 	end
 	
+	context '#sync' do
+		let(:repeats) {10}
+		let(:limit) {2}
+		
+		it 'processes work synchronously with one task' do
+			semaphore = Async::Semaphore.new(limit)
+			
+			result = repeats.times.map do |i|
+				semaphore.sync do |task|
+					expect(semaphore.count).to be == 1
+					task.sleep(rand * 0.1)
+					i
+				end
+			end
+			
+			expect(result).to be == (0...repeats).to_a
+		end
+	end
+	
 	context '#waiting' do
 		subject {Async::Semaphore.new(0)}
 		it 'handles exceptions thrown while waiting' do


### PR DESCRIPTION
This PR adds `Async::Semaphore#sync`. The feature is equivalent to
`Async::Semaphore#acquire` with a block.

It adds a nice symmetry to `Semaphore#async`, and it's similar to`Kernel#Sync`
and `#sync` from `async-await`. The motivation is API aesthetics.

If this PR is accepted, we could simplify `#acquire` by leaving it for
manual use only (acquire + release), no block argument.

## Types of Changes

- [ ] Bug fix.
- [x] New feature.
- [ ] Performance improvement.

## Testing

- [x] I added new tests for my changes.
- [x] I ran all the tests locally.