### PR TITLE
Fix wrapper access in the scheduler

### DIFF
--- a/lib/async/debug/monitor.rb
+++ b/lib/async/debug/monitor.rb
@@ -20,25 +20,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'delegate'
+
 module Async
 	module Debug
-		class Monitor
+		class Monitor < Delegator
 			def initialize(monitor, selector)
 				@monitor = monitor
 				@selector = selector
 			end
 			
+			def __getobj__
+				@monitor
+			end
+			
 			def close
-				@selector.deregister(@monitor.io)
+				@selector.deregister(self)
 				@monitor.close
-			end
-			
-			def method_missing(*arguments, &block)
-				@monitor.send(*arguments)
-			end
-			
-			def respond_to?(*arguments)
-				@monitor.respond_to?(*arguments)
 			end
 			
 			def inspect

--- a/lib/async/debug/selector.rb
+++ b/lib/async/debug/selector.rb
@@ -24,6 +24,7 @@ require_relative 'monitor'
 require_relative '../logger'
 
 require 'nio'
+require 'set'
 
 module Async
 	module Debug
@@ -36,7 +37,7 @@ module Async
 		class Selector
 			def initialize(selector = NIO::Selector.new)
 				@selector = selector
-				@monitors = {}
+				@monitors = Set.new
 			end
 			
 			def register(object, interests)
@@ -46,26 +47,18 @@ module Async
 					raise RuntimeError, "Could not convert #{io} into IO!"
 				end
 				
-				if monitor = @monitors[io.fileno]
-					raise RuntimeError, "Trying to register monitor for #{object.inspect} but it was already registered: #{monitor.inspect}!"
-				end
-				
 				monitor = Monitor.new(@selector.register(object, interests), self)
 				
-				@monitors[io.fileno] = monitor
+				@monitors.add(monitor)
 				
 				return monitor
 			end
 			
-			def deregister(object)
-				Async.logger.debug(self) {"Deregistering #{object.inspect}."}
+			def deregister(monitor)
+				Async.logger.debug(self) {"Deregistering #{monitor.inspect}."}
 				
-				unless io = ::IO.try_convert(object)
-					raise RuntimeError, "Could not convert #{io} into IO!"
-				end
-				
-				unless @monitors.delete(io.fileno)
-					raise RuntimeError, "Trying to remove monitor for #{io.inspect} but it was not registered!"
+				unless @monitors.delete?(monitor)
+					raise RuntimeError, "Trying to remove monitor for #{monitor.inspect} but it was not registered!"
 				end
 			end
 			

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -71,7 +71,7 @@ module Async
 		rescue TimeoutError
 			return nil
 		ensure
-			wrapper.reactor = nil
+			wrapper&.reactor = nil
 		end
 		
 		# Wait for the specified process ID to exit.


### PR DESCRIPTION
## Description

I've noticed this error lately in my recent use of `async-io`:

```
/Users/bryanp/.gem/ruby/3.0.0/gems/async-1.28.9/lib/async/scheduler.rb:74:in `ensure in io_wait': undefined method `reactor=' for nil:NilClass (NoMethodError)
	from /Users/bryanp/.gem/ruby/3.0.0/gems/async-1.28.9/lib/async/scheduler.rb:74:in `io_wait'
	from /Users/bryanp/.rubies/ruby-3.0.0/lib/ruby/3.0.0/socket.rb:304:in `__sendmsg'
	from /Users/bryanp/.rubies/ruby-3.0.0/lib/ruby/3.0.0/socket.rb:304:in `sendmsg'
```

It's been quite tough to reproduce on demand but happens enough I thought it warranted bringing up for discussion.

### Types of Changes

- Bug fix.

### Testing

- [x] I tested my changes locally.
