### PR TITLE
Don't stop transient children, let them propagate up.

### DIFF
--- a/lib/async/reactor.rb
+++ b/lib/async/reactor.rb
@@ -293,19 +293,12 @@ module Async
 			Console.logger.debug(self) {"Exiting run-loop because #{$! ? $! : 'finished'}."}
 		end
 		
-		def stop(later = true)
-			@children&.each do |child|
-				# We don't want this process to propagate `Async::Stop` exceptions, so we schedule tasks to stop later.
-				child.stop(later)
-			end
-		end
-		
 		# Stop each of the children tasks and close the selector.
 		# 
 		# @return [void]
 		def close
-			# This is a critical step. Because tasks could be stored as instance variables, and since the reactor is (probably) going out of scope, we need to ensure they are stopped. Otherwise, the tasks will belong to a reactor that will never run again and are not stopped.
-			self.stop(false)
+			# This is a critical step. Because tasks could be stored as instance variables, and since the reactor is (probably) going out of scope, we need to ensure they are stopped. Otherwise, the tasks will belong to a reactor that will never run again and are not stopped:
+			self.terminate
 			
 			@selector.close
 			@selector = nil

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -156,7 +156,6 @@ module Async
 		# Soon to become attr :result
 		
 		# Stop the task and all of its children.
-		# @return [void]
 		def stop(later = false)
 			if self.stopped?
 				# If we already stopped this task... don't try to stop it again:
@@ -250,9 +249,7 @@ module Async
 			# logger.debug(self) {"Task was stopped with #{@children&.size.inspect} children!"}
 			@status = :stopped
 			
-			@children&.each do |child|
-				child.stop(true) unless child.transient?
-			end
+			stop_children
 		end
 		
 		def make_fiber(&block)

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -251,7 +251,7 @@ module Async
 			@status = :stopped
 			
 			@children&.each do |child|
-				child.stop(true)
+				child.stop(true) unless child.transient?
 			end
 		end
 		

--- a/spec/async/node_spec.rb
+++ b/spec/async/node_spec.rb
@@ -175,7 +175,7 @@ RSpec.describe Async::Node do
 			expect(subject).to be_finished
 			
 			expect(child).to receive(:stop)
-			subject.stop
+			subject.terminate
 		end
 		
 		it 'can move transient sibling to parent' do
@@ -224,6 +224,30 @@ RSpec.describe Async::Node do
 			expect(middle.parent).to be subject
 			expect(subject.children).to include(middle)
 			expect(middle.children).to be_nil
+		end
+		
+		it 'does not stop child transient tasks' do
+			middle = Async::Node.new(subject, annotation: "middle")
+			child1 = Async::Node.new(middle, transient: true, annotation: "child1")
+			child2 = Async::Node.new(middle, annotation: "child2")
+			
+			expect(child1).to_not receive(:stop)
+			expect(child2).to receive(:stop)
+			
+			subject.stop
+		end
+	end
+	
+	describe '#terminate' do
+		it 'stops all tasks' do
+			middle = Async::Node.new(subject, annotation: "middle")
+			child1 = Async::Node.new(middle, transient: true, annotation: "child1")
+			child2 = Async::Node.new(middle, annotation: "child2")
+			
+			expect(child1).to receive(:stop).at_least(:once)
+			expect(child2).to receive(:stop).at_least(:once)
+			
+			subject.terminate
 		end
 	end
 end


### PR DESCRIPTION
## Description

in some situations, transient tasks are created as a child of a specific job, e.g. a connection pool transient gardener could be a child of a specific request. If that request runs to completion, the transient task will propagate up. But explicitly calling stop on that request will currently kill the child transient task. This has potential side effects if other tasks are using the connection pool.

This change allows transient children to propagate up the reactor hierarchy. When killing a task, we don't kill transient children. They should still be killed when the reactor exits, however we should introduce tests for this behaviour.

Fixes #115.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
