### PR TITLE
Use def_delegator instead of alias in Queue

### DIFF
--- a/lib/async/queue.rb
+++ b/lib/async/queue.rb
@@ -20,12 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'forwardable'
+
 require_relative 'notification'
 
 module Async
 	# A queue which allows items to be processed in order.
 	# @public Since `stable-v1`.
 	class Queue < Notification
+		extend Forwardable
+
 		def initialize(parent: nil)
 			super()
 			
@@ -49,7 +53,7 @@ module Async
 			self.signal unless self.empty?
 		end
 		
-		alias << enqueue
+		def_delegator :self, :enqueue, :<<
 		
 		def dequeue
 			while @items.empty?


### PR DESCRIPTION
## Description

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

Replace `alias` with `def_delegator` in `Queue`.

Problem: `Async::LimitedQueue#<<` does not block when the queue is full.

Explanation: both `alias` and `alias_method` despite their misleading names do not create aliases, they create full copies of methods with new names. Therefore if one overrides aliased method in a subclass, the alias name still points to the copy of the original base class method. There are 2 ways of dealing with it:
- defining aliases manually `def new_name(*args, **params) = old_name(*args, **params)`
- using `Forwardable.def_delegator`

Check out a [gist](https://gist.github.com/zhulik/1df6b56d02b2e11f10a28e851da50cd6) and a [blog post](https://theinternate.com/2014/02/14/inheritable-aliases-in-ruby.html)

I'd also recommend replacing aliases everywhere where a class with aliases may potentially be inherited.

Thank you!

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [X] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
