### PR TITLE
Only include *.rb files in gem releases

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |spec|
 	
 	spec.homepage = "https://github.com/socketry/async"
 	
-	spec.files = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH, base: __dir__)
+	spec.files = Dir.glob('{lib}/**/*.rb', File::FNM_DOTMATCH, base: __dir__)
 	
 	spec.required_ruby_version = ">= 3.1.0"
 	


### PR DESCRIPTION
## Description

Gem source code includes a couple markdown files in `lib/async/`. Those markdown files are included in the `.gem` release file.

Old/current files included in the gem release:

```ruby
irb(main):002:0> Dir.glob('{lib}/**/*', File::FNM_DOTMATCH, base: __dir__)
=> 
["lib/.",
 "lib/async",
 "lib/async/barrier.md", # we want to ignore this one
 "lib/async/barrier.rb",
 "lib/async/clock.rb",
 "lib/async/condition.md", # we want to ignore this one
 "lib/async/condition.rb",
 "lib/async/node.rb",
 "lib/async/notification.rb",
 "lib/async/queue.rb",
 "lib/async/reactor.rb",
 "lib/async/scheduler.rb",
 "lib/async/semaphore.md", # we want to ignore this one
 "lib/async/semaphore.rb",
 "lib/async/task.rb",
 "lib/async/variable.rb",
 "lib/async/version.rb",
 "lib/async/wrapper.rb",
 "lib/async.rb",
 "lib/kernel",
 "lib/kernel/async.rb",
 "lib/kernel/sync.rb"]
```

New list of files that will be included in a gem:
```ruby
irb(main):001:0> Dir.glob('{lib}/**/*.rb', File::FNM_DOTMATCH, base: __dir__)
=> 
["lib/async/barrier.rb",
 "lib/async/clock.rb",
 "lib/async/condition.rb",
 "lib/async/node.rb",
 "lib/async/notification.rb",
 "lib/async/queue.rb",
 "lib/async/reactor.rb",
 "lib/async/scheduler.rb",
 "lib/async/semaphore.rb",
 "lib/async/task.rb",
 "lib/async/variable.rb",
 "lib/async/version.rb",
 "lib/async/wrapper.rb",
 "lib/async.rb",
 "lib/kernel/async.rb",
 "lib/kernel/sync.rb"]
```




### Types of Changes

- Maintenance.

### Testing

I think this change is N/A for testing.