### PR TITLE
add option to propogate_errors

### DIFF
--- a/guides/getting-started/README.md
+++ b/guides/getting-started/README.md
@@ -192,6 +192,19 @@ Async do
 end
 ~~~
 
+You can also specify that all unhandled exceptions including `StandardError` be raised immediately using the `:propagate_exceptions` option. If this option is set in a subtask it will apply to the parent task.
+
+~~~ruby
+require 'async'
+
+task = Async(propagate_exceptions: true) do
+	# Exception will be logged and task will be failed.
+	raise "Boom"
+end
+
+# raises RuntimeError: Boom
+~~~
+
 ## Timeouts
 
 You can wrap asynchronous operations in a timeout. This ensures that malicious services don't cause your code to block indefinitely.

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -64,7 +64,9 @@ module Async
 		# @parameter parent [Task] the parent task.
 		def initialize(parent = Task.current?, finished: nil, **options, &block)
 			super(parent, **options)
-			
+
+			@propagate_exceptions = options.fetch(:propagate_exceptions, false)
+
 			@status = :initialized
 			@result = nil
 			@finished = finished
@@ -261,7 +263,7 @@ module Async
 				rescue Stop
 					stop!
 				rescue StandardError => error
-					fail!(error, false)
+					fail!(error, @propagate_exceptions)
 				rescue Exception => exception
 					fail!(exception, true)
 				ensure

--- a/spec/async/task_spec.rb
+++ b/spec/async/task_spec.rb
@@ -90,6 +90,28 @@ RSpec.describe Async::Task do
 				end.to raise_exception RuntimeError, /boom/
 			end
 		end
+
+		it "can propagate exceptions" do
+			reactor.run do
+				expect do
+					reactor.async(propagate_exceptions: true) do |task|
+						raise "boom"
+					end
+				end.to raise_exception RuntimeError, /boom/
+			end
+		end
+
+		it "can propagate nested exceptions" do
+			reactor.run do
+				expect do
+					reactor.async do |task|
+						task.async(propagate_exceptions: true) do |task|
+							raise "boom"
+						end
+					end
+				end.to raise_exception RuntimeError, /boom/
+			end
+		end
 		
 		it "can raise exception after asynchronous operation" do
 			task = nil


### PR DESCRIPTION
## Description
Give users the option to have their tasks operate like the rest of Ruby and have all errors, including `StandardError`, raised without explicitly having to `wait`, or call `result`.

### Types of Changes

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
