### PR TITLE
add option to raise standard errors

### DIFF
--- a/guides/getting-started/README.md
+++ b/guides/getting-started/README.md
@@ -192,6 +192,20 @@ Async do
 end
 ~~~
 
+You can also specify that all unhandled exceptions including `StandardError` be raised immediately using the `:propagate_errors` option. If this option is set in a subtask it will apply to the parent task.
+
+~~~ruby
+require 'async'
+
+Async do |task|
+	task.async(raise_errors: true) do
+		raise "Boom"
+	end
+end
+
+# raises RuntimeError: Boom
+~~~
+
 ## Timeouts
 
 You can wrap asynchronous operations in a timeout. This ensures that malicious services don't cause your code to block indefinitely.

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -62,9 +62,11 @@ module Async
 		# Create a new task.
 		# @parameter reactor [Reactor] the reactor this task will run within.
 		# @parameter parent [Task] the parent task.
-		def initialize(parent = Task.current?, finished: nil, **options, &block)
+		def initialize(parent = Task.current?, raise_errors: false, finished: nil, **options, &block)
 			super(parent, **options)
-			
+
+			@raise_errors = raise_errors
+
 			@status = :initialized
 			@result = nil
 			@finished = finished
@@ -261,7 +263,7 @@ module Async
 				rescue Stop
 					stop!
 				rescue StandardError => error
-					fail!(error, false)
+					fail!(error, @raise_errors)
 				rescue Exception => exception
 					fail!(exception, true)
 				ensure

--- a/spec/async/task_spec.rb
+++ b/spec/async/task_spec.rb
@@ -90,7 +90,29 @@ RSpec.describe Async::Task do
 				end.to raise_exception RuntimeError, /boom/
 			end
 		end
-		
+
+		it "can raise errors" do
+			expect do
+				Async do |task|
+					task.async(raise_errors: true) do |task|
+						raise "boom"
+					end
+				end
+			end.to raise_exception RuntimeError, /boom/
+		end
+
+		it "can raise nested errors" do
+			expect do
+				Async do |task|
+					task.async do |task|
+						task.async(raise_errors: true) do
+							raise "boom"
+						end
+					end
+				end
+			end.to raise_exception RuntimeError, /boom/
+		end
+
 		it "can raise exception after asynchronous operation" do
 			task = nil
 			


### PR DESCRIPTION
## Description
Give users the option to have their tasks operate like the rest of Ruby and have all errors, including `StandardError`, raised without explicitly having to `wait`, or call `result`.

### Types of Changes

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.