### PR TITLE
Modify `yield timer` to `yield timeout` in `Scheduler#timeout_after`

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -291,7 +291,7 @@ module Async
 				end
 			end
 			
-			yield timer
+			yield timeout
 		ensure
 			timer.cancel if timer
 		end


### PR DESCRIPTION
## Description

### Why

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

In the current implementation of `Async::Scheduler#timeout_after`, it executes the given block with the **timer** as the block argument as below.


```rb
    yield timer
```
(from. https://github.com/socketry/async/blob/v2.0.0/lib/async/scheduler.rb#L294)

However, in ruby 3.1, the scheduler which is set to the thread is triggered as below.

```rb
  def timeout(sec, klass = nil, message = nil, &block)   #:yield: +sec+
    # some lines are ommited here.

    if Fiber.respond_to?(:current_scheduler) && (scheduler = Fiber.current_scheduler)&.respond_to?(:timeout_after)
      return scheduler.timeout_after(sec, klass || Error, message, &block)
    end
```
(from. https://github.com/ruby/ruby/blob/ruby_3_1/lib/timeout.rb#L88-L90)

When both `Timeout#timeout` and `Timeout.timeout` is called, **they take the block argument as timeout(second), not as a Timer object**. This is also described in the official doc as below.

> timeout(sec, klass = nil, message = nil) { |sec| ... }
> 
> from. https://docs.ruby-lang.org/en/3.1/Timeout.html

This should be fixed.


### What

`Async::Scheduler#timeout_after` executes the given block with passing timeout as the argument.

```rb
    yield timeout
```

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
