### PR TITLE
Ensure timeout_after yields duration.

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -282,10 +282,10 @@ module Async
 		
 		# Invoke the block, but after the specified timeout, raise {TimeoutError} in any currenly blocking operation. If the block runs to completion before the timeout occurs or there are no non-blocking operations after the timeout expires, the code will complete without any exception.
 		# @parameter duration [Numeric] The time in seconds, in which the task should complete.
-		def timeout_after(timeout, exception = TimeoutError, message = "execution expired", &block)
+		def with_timeout(duration, exception = TimeoutError, message = "execution expired", &block)
 			fiber = Fiber.current
 			
-			timer = @timers.after(timeout) do
+			timer = @timers.after(duration) do
 				if fiber.alive?
 					fiber.raise(exception, message)
 				end
@@ -294,6 +294,12 @@ module Async
 			yield timer
 		ensure
 			timer.cancel if timer
+		end
+		
+		def timeout_after(duration, exception, message, &block)
+			with_timeout(duration, exception, message) do |timer|
+				yield duration
+			end
 		end
 	end
 end

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -92,9 +92,9 @@ module Async
 			super
 		end
 		
-		# @deprecated Replaced by {Scheduler#timeout_after}.
-		def with_timeout(timeout, exception = TimeoutError, message = "execution expired", &block)
-			Fiber.scheduler.timeout_after(timeout, exception, message, &block)
+		# Execute the given block of code, raising the specified exception if it exceeds the given duration during a non-blocking operation.
+		def with_timeout(duration, exception = TimeoutError, message = "execution expired", &block)
+			Fiber.scheduler.with_timeout(duration, exception, message, &block)
 		end
 		
 		# Yield back to the reactor and allow other fibers to execute.

--- a/spec/async/scheduler/timeout_spec.rb
+++ b/spec/async/scheduler/timeout_spec.rb
@@ -1,4 +1,4 @@
-# Copyright, 2020, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# Copyright, 2021, by Samuel G. D. Williams. <http://www.codeotaku.com>
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -18,22 +18,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require_relative 'scheduler'
+require 'async/scheduler'
 
-module Async
-	# A wrapper around the the scheduler which binds it to the current thread automatically.
-	class Reactor < Scheduler
-		# @deprecated Replaced by {Kernel::Async}.
-		def self.run(...)
-			Async(...)
+require 'timeout'
+
+RSpec.describe Async::Scheduler, if: Async::Scheduler.supported? do
+	include_context Async::RSpec::Reactor
+	
+	describe ::Timeout do
+		it "can invoke timeout and receive timeout as block argument" do
+			::Timeout.timeout(1.0) do |duration|
+				expect(duration).to be == 1.0
+			end
 		end
-		
-		def initialize(...)
-			super
-			
-			Fiber.set_scheduler(self)
-		end
-		
-		public :sleep
 	end
 end


### PR DESCRIPTION
## Description

As discussed in https://github.com/socketry/async/pull/145

We need to retain backwards compatibility with Async 1 interface `with_timeout` which is an acceptable middle ground.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Breaking change.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
