### PR TITLE
Fix handling of barriers when waiting on a task fails with an unrelated exception.

### DIFF
--- a/lib/async/barrier.rb
+++ b/lib/async/barrier.rb
@@ -69,8 +69,11 @@ module Async
 				begin
 					task.wait
 				ensure
-					# Remove the task from the waiting list if it's finished:
-					@tasks.shift if @tasks.first == task
+					# We don't know for sure that the exception was due to the task completion.
+					unless task.running?
+						# Remove the task from the waiting list if it's finished:
+						@tasks.shift if @tasks.first == task
+					end
 				end
 			end
 		end

--- a/spec/async/barrier_spec.rb
+++ b/spec/async/barrier_spec.rb
@@ -92,6 +92,27 @@ RSpec.describe Async::Barrier do
 			
 			expect(order).to be == [0, 1, 2, 3, 4]
 		end
+		
+		# It's possible for Barrier#wait to be interrupted with an unexpected exception, and this should not cause the barrier to incorrectly remove that task from the wait list.
+		it 'waits for tasks with timeouts' do
+			begin
+				reactor.with_timeout(0.25) do
+					5.times do |i|
+						subject.async do |task|
+							task.sleep(i/10.0)
+						end
+					end
+					
+					expect(subject.tasks.size).to be == 5
+					subject.wait
+				end
+			rescue Async::TimeoutError
+				# Expected.
+			ensure
+				expect(subject.tasks.size).to be == 2
+				subject.stop
+			end
+		end
 	end
 	
 	describe '#stop' do


### PR DESCRIPTION
When using a barrier with a timeout, there was a bug where the task would be removed from the task list even though it was still running, causing `Barrier#stop` to later miss stopping the task and leak it.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
