### PR TITLE
Log as warning rather than error, and with explicit message.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -224,18 +224,19 @@ module Async
 		private
 		
 		# This is a very tricky aspect of tasks to get right. I've modelled it after `Thread` but it's slightly different in that the exception can propagate back up through the reactor. If the user writes code which raises an exception, that exception should always be visible, i.e. cause a failure. If it's not visible, such code fails silently and can be very difficult to debug.
-		# As an explcit choice, the user can start a task which doesn't propagate exceptions. This only applies to `StandardError` and derived tasks. This allows tasks to internally capture their error state which is raised when invoking `Task#result` similar to how `Thread#join` works. This mode makes {ruby Async::Task} behave more like a promise, and you would need to ensure that someone calls `Task#result` otherwise you might miss important errors.
-		def fail!(exception = nil, propagate = true)
+		def fail!(exception = false, propagate = true)
 			@status = :failed
 			@result = exception
 			
-			if propagate
-				raise
-			elsif @finished.nil?
-				# If no one has called wait, we log this as an error:
-				Console.logger.error(self) {$!}
-			else
-				Console.logger.debug(self) {$!}
+			if exception
+				if propagate
+					raise exception
+				elsif @finished.nil?
+					# If no one has called wait, we log this as a warning:
+					Console.logger.warn(self, "Task may have ended with unhandled exception.", exception)
+				else
+					Console.logger.debug(self, exception)
+				end
 			end
 		end
 		


### PR DESCRIPTION
At best these errors are harmless and at worst they represent a logic error in the program. Since we expect this to mostly be a false positive, change it to a warning.

### Types of Changes

- New feature.
