### PR TITLE
Add Async::Waiter

### DIFF
--- a/lib/async/waiter.rb
+++ b/lib/async/waiter.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require_relative 'barrier'
+
+module Async
+	class Waiter < Barrier
+		def initialize(parent: nil)
+			super
+			@finished = Async::Condition.new
+			@all_tasks = []
+			@done = []
+		end
+
+		def async(*arguments, parent: (@parent or Task.current), **options)
+			t = parent.async(*arguments, **options) do |task|
+				yield(task)
+			ensure
+				@done << task
+				@finished.signal
+			end
+
+			@tasks << t
+			@all_tasks << t
+			t
+		end
+
+		def wait_for(n = size)
+			raise ArgumentError, "'n' cannot be greater than size. Given: #{n}, size: #{size}" if n > size
+
+			while @done.size < n
+				@finished.wait
+			end
+
+			done = @done.first(n)
+			[done, @all_tasks - done]
+		ensure
+			@tasks.filter!{ |t| !@done.include?(t) }
+		end
+
+		def wait(n = size)
+			wait_for(n).first.map(&:wait)
+		end
+	end
+end

--- a/spec/async/barrier_examples.rb
+++ b/spec/async/barrier_examples.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'async/clock'
+require 'async/rspec'
+require 'async/semaphore'
+
+require_relative 'chainable_async_examples'
+
+RSpec.shared_examples 'barrier' do
+	describe '#async' do
+		let(:repeats) {40}
+		let(:delay) {0.1}
+
+		it 'should wait for all jobs to complete' do
+			finished = 0
+
+			repeats.times.map do |i|
+				subject.async do |task|
+					task.sleep(delay)
+					finished += 1
+
+					# This task is a child task but not part of the barrier.
+					task.async do
+						task.sleep(delay*3)
+					end
+				end
+			end
+
+			expect(subject).to_not be_empty
+			expect(finished).to be < repeats
+
+			duration = Async::Clock.measure{subject.wait}
+
+			expect(duration).to be < (delay * 2 * Q)
+			expect(finished).to be == repeats
+			expect(subject).to be_empty
+		end
+	end
+
+	describe '#wait' do
+		it 'should wait for tasks even after exceptions' do
+			task1 = subject.async do
+				raise "Boom"
+			end
+
+			task2 = subject.async do
+			end
+
+			expect(task1).to be_failed
+			expect(task2).to be_finished
+
+			expect{subject.wait}.to raise_exception(/Boom/)
+
+			subject.wait until subject.empty?
+
+			expect(subject).to be_empty
+		end
+
+		it 'waits for tasks in order' do
+			order = []
+
+			5.times do |i|
+				subject.async do
+					order << i
+				end
+			end
+
+			subject.wait
+
+			expect(order).to be == [0, 1, 2, 3, 4]
+		end
+
+		# It's possible for Barrier#wait to be interrupted with an unexpected exception, and this should not cause the barrier to incorrectly remove that task from the wait list.
+		it 'waits for tasks with timeouts' do
+			begin
+				reactor.with_timeout(0.25) do
+					5.times do |i|
+						subject.async do |task|
+							task.sleep(i/10.0)
+						end
+					end
+
+					expect(subject.tasks.size).to be == 5
+					subject.wait
+				end
+			rescue Async::TimeoutError
+				# Expected.
+			ensure
+				expect(subject.tasks.size).to be == 2
+				subject.stop
+			end
+		end
+	end
+
+	describe '#stop' do
+		it "can stop several tasks" do
+			task1 = subject.async do |task|
+				task.sleep(10)
+			end
+
+			task2 = subject.async do |task|
+				task.sleep(10)
+			end
+
+			subject.stop
+
+			expect(task1).to be_stopped
+			expect(task2).to be_stopped
+		end
+
+		it "can stop several tasks when waiting on barrier" do
+			task1 = subject.async do |task|
+				task.sleep(10)
+			end
+
+			task2 = subject.async do |task|
+				task.sleep(10)
+			end
+
+			task3 = reactor.async do
+				subject.wait
+			end
+
+			subject.stop
+
+			task1.wait
+			task2.wait
+
+			expect(task1).to be_stopped
+			expect(task2).to be_stopped
+
+			task3.wait
+		end
+
+		it "several tasks can wait on the same barrier" do
+			task1 = subject.async do |task|
+				task.sleep(10)
+			end
+
+			task2 = reactor.async do |task|
+				subject.wait
+			end
+
+			task3 = reactor.async do
+				subject.wait
+			end
+
+			subject.stop
+
+			task1.wait
+
+			expect(task1).to be_stopped
+
+			task2.wait
+			task3.wait
+		end
+	end
+
+	context 'with semaphore' do
+		let(:capacity) {2}
+		let(:semaphore) {Async::Semaphore.new(capacity)}
+		let(:repeats) {capacity * 2}
+
+		it 'should execute several tasks and wait using a barrier' do
+			repeats.times do
+				subject.async(parent: semaphore) do |task|
+					task.sleep 0.1
+				end
+			end
+
+			expect(subject.size).to be == repeats
+			subject.wait
+		end
+	end
+
+	it_behaves_like 'chainable async'
+end

--- a/spec/async/barrier_spec.rb
+++ b/spec/async/barrier_spec.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
 # Copyright, 2019, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,180 +21,11 @@
 # THE SOFTWARE.
 
 require 'async/barrier'
-require 'async/clock'
-require 'async/rspec'
-require 'async/semaphore'
 
-require_relative 'chainable_async_examples'
+require_relative 'barrier_examples'
 
 RSpec.describe Async::Barrier do
 	include_context Async::RSpec::Reactor
-	
-	describe '#async' do
-		let(:repeats) {40}
-		let(:delay) {0.1}
-		
-		it 'should wait for all jobs to complete' do
-			finished = 0
-			
-			repeats.times.map do |i|
-				subject.async do |task|
-					task.sleep(delay)
-					finished += 1
-					
-					# This task is a child task but not part of the barrier.
-					task.async do
-						task.sleep(delay*3)
-					end
-				end
-			end
-			
-			expect(subject).to_not be_empty
-			expect(finished).to be < repeats
-			
-			duration = Async::Clock.measure{subject.wait}
-			
-			expect(duration).to be < (delay * 2 * Q)
-			expect(finished).to be == repeats
-			expect(subject).to be_empty
-		end
-	end
-	
-	describe '#wait' do
-		it 'should wait for tasks even after exceptions' do
-			task1 = subject.async do
-				raise "Boom"
-			end
-			
-			task2 = subject.async do
-			end
-			
-			expect(task1).to be_failed
-			expect(task2).to be_finished
-			
-			expect{subject.wait}.to raise_exception(/Boom/)
-			
-			subject.wait until subject.empty?
-			
-			expect(subject).to be_empty
-		end
-		
-		it 'waits for tasks in order' do
-			order = []
-			
-			5.times do |i|
-				subject.async do
-					order << i
-				end
-			end
-			
-			subject.wait
-			
-			expect(order).to be == [0, 1, 2, 3, 4]
-		end
-		
-		# It's possible for Barrier#wait to be interrupted with an unexpected exception, and this should not cause the barrier to incorrectly remove that task from the wait list.
-		it 'waits for tasks with timeouts' do
-			begin
-				reactor.with_timeout(0.25) do
-					5.times do |i|
-						subject.async do |task|
-							task.sleep(i/10.0)
-						end
-					end
-					
-					expect(subject.tasks.size).to be == 5
-					subject.wait
-				end
-			rescue Async::TimeoutError
-				# Expected.
-			ensure
-				expect(subject.tasks.size).to be == 2
-				subject.stop
-			end
-		end
-	end
-	
-	describe '#stop' do
-		it "can stop several tasks" do
-			task1 = subject.async do |task|
-				task.sleep(10)
-			end
-			
-			task2 = subject.async do |task|
-				task.sleep(10)
-			end
-			
-			subject.stop
-			
-			expect(task1).to be_stopped
-			expect(task2).to be_stopped
-		end
-		
-		it "can stop several tasks when waiting on barrier" do
-			task1 = subject.async do |task|
-				task.sleep(10)
-			end
-			
-			task2 = subject.async do |task|
-				task.sleep(10)
-			end
-			
-			task3 = reactor.async do
-				subject.wait
-			end
-			
-			subject.stop
-			
-			task1.wait
-			task2.wait
-			
-			expect(task1).to be_stopped
-			expect(task2).to be_stopped
-			
-			task3.wait
-		end
-		
-		it "several tasks can wait on the same barrier" do
-			task1 = subject.async do |task|
-				task.sleep(10)
-			end
-			
-			task2 = reactor.async do |task|
-				subject.wait
-			end
-			
-			task3 = reactor.async do
-				subject.wait
-			end
-			
-			subject.stop
-			
-			task1.wait
-			
-			expect(task1).to be_stopped
-			
-			task2.wait
-			task3.wait
-		end
-	end
-	
-	context 'with semaphore' do
-		let(:capacity) {2}
-		let(:semaphore) {Async::Semaphore.new(capacity)}
-		let(:repeats) {capacity * 2}
-		
-		it 'should execute several tasks and wait using a barrier' do
-			repeats.times do
-				subject.async(parent: semaphore) do |task|
-					task.sleep 0.1
-				end
-			end
-			
-			expect(subject.size).to be == repeats
-			subject.wait
-		end
-	end
-	
-	it_behaves_like 'chainable async'
+
+	it_behaves_like 'barrier'
 end

--- a/spec/async/waiter_spec.rb
+++ b/spec/async/waiter_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'async/waiter'
+
+require_relative 'barrier_examples'
+
+RSpec.describe Async::Waiter do
+	include_context Async::RSpec::Reactor
+
+	it_behaves_like 'barrier'
+end


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

**WIP**

As discussed [here](https://github.com/socketry/async/issues/62) I introduce a new class called `Waiter` which can be a drop-in replacement  `Barrier`. The only difference is that it can await for first N tasks.

Once and if the approach is approved I'll add more specific tests

Questions:
- Better name?
- Replace Barrier?
- How to get rid of warnings in logs when a task raises an exception? See example:
```ruby
Async do |task|
  waiter = Async::Waiter.new
  waiter.async do
    task.sleep(1)
    raise StandardError, "Error!"
  end
  waiter.async do
    task.sleep(2)
    2
  end
  waiter.async do
    task.sleep(3)
    3
  end
  waiter.async do
    task.sleep(3)
    raise StandardError, "Error!"
  end

  done, pending = waiter.wait_for(2)

  done.each do |task|
    Console.logger.info(self, "Done result: #{task.wait}")
  rescue StandardError => e
    Console.logger.info(self, e)
  end

  pending.each do |task|
    Console.logger.info(self, "Pending result: #{task.wait}")
  rescue StandardError => e
    Console.logger.info(self, e)
  end
  Console.logger.info(self, "Done")
end
```

Even though the tasks with raises have eventually been awaited, I still see warnings in the logs:
```
  0.0s     warn: Async::Task [oid=0x8c] [ec=0xa0] [pid=453505] [2022-07-30 23:31:16 +0200]
               | Task may have ended with unhandled exception.
               |   StandardError: Error!
               |   → ./waiter.rb:56 in `block (2 levels) in <main>'
               |     ./waiter.rb:20 in `block in async'
               |     /home/zhulik/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/async-2.0.3/lib/async/task.rb:255 in `block in schedule'
  1.0s     info: Object [oid=0xb4] [ec=0xc8] [pid=453505] [2022-07-30 23:31:17 +0200]
               |   StandardError: Error!
               |   → ./waiter.rb:56 in `block (2 levels) in <main>'
               |     ./waiter.rb:20 in `block in async'
               |     /home/zhulik/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/async-2.0.3/lib/async/task.rb:255 in `block in schedule'
  1.0s     info: Object [oid=0xb4] [ec=0xc8] [pid=453505] [2022-07-30 23:31:17 +0200]
               | Done result: 2
  2.0s     info: Object [oid=0xb4] [ec=0xc8] [pid=453505] [2022-07-30 23:31:18 +0200]
               | Pending result: 3
  2.0s     info: Object [oid=0xb4] [ec=0xc8] [pid=453505] [2022-07-30 23:31:18 +0200]
               |   StandardError: Error!
               |   → ./waiter.rb:68 in `block (2 levels) in <main>'
               |     ./waiter.rb:20 in `block in async'
               |     /home/zhulik/.asdf/installs/ruby/3.1.2/lib/ruby/gems/3.1.0/gems/async-2.0.3/lib/async/task.rb:255 in `block in schedule'
  2.0s     info: Object [oid=0xb4] [ec=0xc8] [pid=453505] [2022-07-30 23:31:18 +0200]
               | Done
```

**Note**: I'm leaving on vacation on August 2, the day after tomorrow and won't be able to code till August 9.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
