### PR TITLE
Make it possible to wrap/intercept task setup.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -117,7 +117,9 @@ module Async
 			if @status == :initialized
 				@status = :running
 				
-				schedule(arguments)
+				schedule do
+					@block.call(self, *arguments)
+				end
 			else
 				raise RuntimeError, "Task already running!"
 			end
@@ -247,12 +249,12 @@ module Async
 			stop_children(true)
 		end
 		
-		def schedule(arguments)
+		def schedule(&block)
 			@fiber = Fiber.new do
 				set!
 				
 				begin
-					@result = @block.call(self, *arguments)
+					@result = yield
 					@status = :complete
 					# Console.logger.debug(self) {"Task was completed with #{@children.size} children!"}
 				rescue Stop


### PR DESCRIPTION
In order to add traces to async, we need to be able to wrap the scheduled fiber.

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.
