### PR TITLE
Linked list2

### DIFF
--- a/lib/async/condition.rb
+++ b/lib/async/condition.rb
@@ -11,35 +11,75 @@ module Async
 	# A synchronization primitive, which allows fibers to wait until a particular condition is (edge) triggered.
 	# @public Since `stable-v1`.
 	class Condition
-		def initialize
-			@waiting = []
+		class List
+			def initialize
+				@head = self
+				@tail = self
+			end
+			
+			# @private
+			attr_accessor :head
+			
+			# @private
+			attr_accessor :tail
+			
+			def insert(node)
+				node.tail = self
+				@head.tail = node
+				node.head = @head
+				@head = node
+			end
+			
+			def delete!
+				@head.tail = @tail
+				@tail.head = @head
+				@head = nil
+				@tail = nil
+			end
+			
+			def empty?
+				@tail == self
+			end
+			
+			def each
+				node = @tail
+				
+				while node != self
+					tail = node.tail
+					yield node
+					node = tail
+				end
+			end
 		end
-		
-		Queue = Struct.new(:fiber) do
+	
+		class Queue < List
+			def initialize(fiber)
+				super()
+				@fiber = fiber
+			end
+			
 			def transfer(*arguments)
-				fiber&.transfer(*arguments)
+				@fiber.transfer(*arguments)
 			end
 			
 			def alive?
-				fiber&.alive?
-			end
-			
-			def nullify
-				self.fiber = nil
+				@fiber.alive?
 			end
 		end
 		
-		private_constant :Queue
+		def initialize
+			@waiting = List.new
+		end
 		
 		# Queue up the current fiber and wait on yielding the task.
 		# @returns [Object]
 		def wait
 			queue = Queue.new(Fiber.current)
-			@waiting << queue
+			@waiting.insert(queue)
 			
 			Fiber.scheduler.transfer
 		ensure
-			queue.nullify
+			queue.delete!
 		end
 		
 		# Is any fiber waiting on this notification?
@@ -51,14 +91,23 @@ module Async
 		# Signal to a given task that it should resume operations.
 		# @parameter value [Object | Nil] The value to return to the waiting fibers.
 		def signal(value = nil)
-			waiting = @waiting
-			@waiting = []
+			return if @waiting.empty?
+			
+			waiting = self.exchange
 			
 			waiting.each do |fiber|
 				Fiber.scheduler.resume(fiber, value) if fiber.alive?
 			end
 			
 			return nil
+		end
+		
+		protected
+		
+		def exchange
+			waiting = @waiting
+			@waiting = List.new
+			return waiting
 		end
 	end
 end

--- a/lib/async/condition.rb
+++ b/lib/async/condition.rb
@@ -29,6 +29,8 @@ module Async
 			end
 		end
 		
+		private_constant :Waiter
+		
 		# Queue up the current fiber and wait on yielding the task.
 		# @returns [Object]
 		def wait

--- a/lib/async/condition.rb
+++ b/lib/async/condition.rb
@@ -11,62 +11,6 @@ module Async
 	# A synchronization primitive, which allows fibers to wait until a particular condition is (edge) triggered.
 	# @public Since `stable-v1`.
 	class Condition
-		class List
-			def initialize
-				@head = self
-				@tail = self
-			end
-			
-			# @private
-			attr_accessor :head
-			
-			# @private
-			attr_accessor :tail
-			
-			def insert(node)
-				node.tail = self
-				@head.tail = node
-				node.head = @head
-				@head = node
-			end
-			
-			def delete!
-				@head.tail = @tail
-				@tail.head = @head
-				@head = nil
-				@tail = nil
-			end
-			
-			def empty?
-				@tail == self
-			end
-			
-			def each
-				node = @tail
-				
-				while node != self
-					tail = node.tail
-					yield node
-					node = tail
-				end
-			end
-		end
-	
-		class Queue < List
-			def initialize(fiber)
-				super()
-				@fiber = fiber
-			end
-			
-			def transfer(*arguments)
-				@fiber.transfer(*arguments)
-			end
-			
-			def alive?
-				@fiber.alive?
-			end
-		end
-		
 		def initialize
 			@waiting = List.new
 		end

--- a/lib/async/list.rb
+++ b/lib/async/list.rb
@@ -40,16 +40,8 @@ module Async
 			node.tail.head = node.head
 			node.head = nil
 			node.tail = nil
-		end
-		
-		# Delete the node from the list.
-		def delete!
-			@head.tail = @tail
-			@tail.head = @head
-			@head = nil
-			@tail = nil
 			
-			return self
+			return node
 		end
 		
 		def empty?
@@ -96,6 +88,21 @@ module Async
 		
 		def nil?
 			@tail == self
+		end
+	end
+	
+	class List::Node
+		attr_accessor :head
+		attr_accessor :tail
+		
+		# Delete the node from the list.
+		def delete!
+			@head.tail = @tail
+			@tail.head = @head
+			@head = nil
+			@tail = nil
+			
+			return self
 		end
 	end
 end

--- a/lib/async/list.rb
+++ b/lib/async/list.rb
@@ -45,7 +45,7 @@ module Async
 		end
 		
 		def empty?
-			@tail == self
+			@tail.equal?(self)
 		end
 		
 		def each
@@ -80,14 +80,6 @@ module Async
 		
 		def last
 			@head
-		end
-		
-		def empty?
-			@tail == self
-		end
-		
-		def nil?
-			@tail == self
 		end
 	end
 	

--- a/lib/async/list.rb
+++ b/lib/async/list.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022, by Samuel Williams.
+
+module Async
+	class List
+		def initialize
+			@head = self
+			@tail = self
+		end
+		
+		# @private
+		attr_accessor :head
+		
+		# @private
+		attr_accessor :tail
+		
+		# Append a node to the end of the list.
+		def append(node)
+			node.tail = self
+			@head.tail = node
+			node.head = @head
+			@head = node
+			
+			return node
+		end
+		
+		def prepend(node)
+			node.head = self
+			@tail.head = node
+			node.tail = @tail
+			@tail = node
+			
+			return node
+		end
+		
+		def delete(node)
+			node.head.tail = node.tail
+			node.tail.head = node.head
+			node.head = nil
+			node.tail = nil
+		end
+		
+		# Delete the node from the list.
+		def delete!
+			@head.tail = @tail
+			@tail.head = @head
+			@head = nil
+			@tail = nil
+			
+			return self
+		end
+		
+		def empty?
+			@tail == self
+		end
+		
+		def each
+			return to_enum unless block_given?
+			
+			current = self
+			
+			while true
+				node = current.tail
+				break if node.equal?(self)
+				
+				yield node
+				
+				# If the node has deleted itself or any subsequent node, it will no longer be the next node, so don't use it for continued traversal:
+				if current.tail.equal?(node)
+					current = node
+				end
+			end
+		end
+		
+		def include?(needle)
+			self.each do |item|
+				return true if needle.equal?(item)
+			end
+			
+			return false
+		end
+		
+		def first
+			@tail
+		end
+		
+		def last
+			@head
+		end
+		
+		def empty?
+			@tail == self
+		end
+		
+		def nil?
+			@tail == self
+		end
+	end
+end

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -44,6 +44,10 @@ module Async
 			@size == @transient_count
 		end
 		
+		def nil?
+			empty?
+		end
+		
 		private
 		
 		def added(node)
@@ -106,7 +110,7 @@ module Async
 		
 		# Whether there are children?
 		def children?
-			!@children.nil?
+			@children && !@children.empty?
 		end
 		
 		# Is this node transient?

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -5,138 +5,61 @@
 # Copyright, 2017, by Kent Gruber.
 # Copyright, 2022, by Shannon Skipper.
 
+require_relative 'list'
+
 module Async
-	# A double linked list used for managing tasks.
-	class List
-		def initialize
-			# The list behaves like a list node, so @tail points to the next item (the first one) and head points to the previous item (the last one). This may be slightly confusing but it makes the interface more natural.
-			@head = nil
-			@tail = nil
-			@size = 0
-		end
-		
-		attr :size
-		
-		attr_accessor :head
-		attr_accessor :tail
-		
-		# Inserts an item at the end of the list.
-		def insert(item)
-			unless @tail
-				@tail = item
-				@head = item
-				
-				# Consistency:
-				item.head = nil
-				item.tail = nil
-			else
-				@head.tail = item
-				item.head = @head
-				
-				# Consistency:
-				item.tail = nil
-				
-				@head = item
-			end
-			
-			@size += 1
-			
-			return self
-		end
-		
-		def delete(item)
-			if @tail.equal?(item)
-				@tail = @tail.tail
-			else
-				item.head.tail = item.tail
-			end
-			
-			if @head.equal?(item)
-				@head = @head.head
-			else
-				item.tail.head = item.head
-			end
-			
-			item.head = nil
-			item.tail = nil
-			
-			@size -= 1
-			
-			return self
-		end
-		
-		def each(&block)
-			return to_enum unless block_given?
-			
-			current = self
-			while node = current.tail
-				yield node
-				
-				# If the node has deleted itself or any subsequent node, it will no longer be the next node, so don't use it for continued traversal:
-				if current.tail.equal?(node)
-					current = node
-				end
-			end
-		end
-		
-		def include?(needle)
-			self.each do |item|
-				return true if needle.equal?(item)
-			end
-			
-			return false
-		end
-		
-		def first
-			@tail
-		end
-		
-		def last
-			@head
-		end
-		
-		def empty?
-			@tail.nil?
-		end
-		
-		def nil?
-			@tail.nil?
-		end
-	end
-	
-	private_constant :List
-	
 	# A list of children tasks.
 	class Children < List
 		def initialize
 			super
 			
+			@size = 0
 			@transient_count = 0
 		end
+		
+		attr :size
 		
 		# Does this node have (direct) transient children?
 		def transients?
 			@transient_count > 0
 		end
 		
-		def insert(item)
-			if item.transient?
-				@transient_count += 1
-			end
-			
-			super
+		def insert(child)
+			append(child)
 		end
 		
-		def delete(item)
-			if item.transient?
-				@transient_count -= 1
-			end
-			
-			super
+		def append(node)
+			added(super)
+		end
+		
+		def prepend(node)
+			added(super)
+		end
+		
+		def delete(node)
+			removed(super)
 		end
 		
 		def finished?
-			@size == @transient_count
+			@count == @transient_count
+		end
+		
+		private
+		
+		def added(node)
+			if node.transient?
+				@transient_count += 1
+			end
+			
+			@size += 1
+		end
+		
+		def removed(node)
+			if node.transient?
+				@transient_count -= 1
+			end
+			
+			@size -= 1
 		end
 	end
 	
@@ -183,7 +106,7 @@ module Async
 		
 		# Whether there are children?
 		def children?
-			@children != nil && !@children.empty?
+			!@children.nil?
 		end
 		
 		# Is this node transient?

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -41,7 +41,7 @@ module Async
 		end
 		
 		def finished?
-			@count == @transient_count
+			@size == @transient_count
 		end
 		
 		private

--- a/lib/async/notification.rb
+++ b/lib/async/notification.rb
@@ -13,9 +13,7 @@ module Async
 		def signal(value = nil, task: Task.current)
 			return if @waiting.empty?
 			
-			Fiber.scheduler.push Signal.new(@waiting, value)
-			
-			@waiting = []
+			Fiber.scheduler.push Signal.new(self.exchange, value)
 			
 			return nil
 		end

--- a/spec/async/list_spec.rb
+++ b/spec/async/list_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2017-2022, by Samuel Williams.
+# Copyright, 2022, by Shannon Skipper.
+
+require 'async/list'
+
+class Item < Async::List::Node
+	def initialize(value)
+		super()
+		@value = value
+	end
+	
+	attr_accessor :value
+end
+
+RSpec.describe Async::List do
+	let(:list) {Async::List.new}
+	
+	it "can append items" do
+		list.append(Item.new(1))
+		list.append(Item.new(2))
+		list.append(Item.new(3))
+		
+		expect(list.each.map(&:value)).to be == [1, 2, 3]
+	end
+	
+	it "can prepend items" do
+		list.prepend(Item.new(1))
+		list.prepend(Item.new(2))
+		list.prepend(Item.new(3))
+		
+		expect(list.each.map(&:value)).to be == [3, 2, 1]
+	end
+	
+	it "can remove items" do
+		item = Item.new(1)
+		
+		list.append(item)
+		list.delete(item)
+		
+		expect(list.each.map(&:value)).to be_empty
+	end
+	
+	it "can remove items from the middle" do
+		item = Item.new(1)
+		
+		list.append(Item.new(2))
+		list.append(item)
+		list.append(Item.new(3))
+		
+		list.delete(item)
+		
+		expect(list.each.map(&:value)).to be == [2, 3]
+	end
+end


### PR DESCRIPTION
This PR unifies the linked list implementation between `Async::Children` and `Async::Condition` which is a good place to be, since in the future I want to provide native implementations (like `io-event` gem ready list). This has identical semantics (FIFO) and deletion characteristics.

Fixes <https://github.com/socketry/async/pull/186> and <https://github.com/socketry/async/issues/176>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
