### PR TITLE
Restore 100% coverage.

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 	spec.add_development_dependency "bake-test-external"
 	spec.add_development_dependency "benchmark-ips"
 	spec.add_development_dependency "bundler"
-	spec.add_development_dependency "covered", "~> 0.10"
+	spec.add_development_dependency "covered", "~> 0.18.3"
 	spec.add_development_dependency "sus", "~> 0.15"
 	spec.add_development_dependency "sus-fixtures-async"
 end

--- a/gems.rb
+++ b/gems.rb
@@ -16,6 +16,3 @@ group :maintenance, optional: true do
 	gem "bake-github-pages"
 	gem "utopia-project"
 end
-
-# gem "async-rspec", path: "../async-rspec"
-# gem "rspec-files", path: "../rspec-files"

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -24,17 +24,11 @@ module Async
 			@transient_count > 0
 		end
 		
-		def insert(child)
-			append(child)
-		end
-		
 		def append(node)
 			added(super)
 		end
 		
-		def prepend(node)
-			added(super)
-		end
+		undef prepend
 		
 		def delete(node)
 			removed(super)
@@ -175,7 +169,7 @@ module Async
 		
 		protected def add_child(child)
 			@children ||= Children.new
-			@children.insert(child)
+			@children.append(child)
 			child.set_parent(self)
 		end
 		

--- a/test/async/children.rb
+++ b/test/async/children.rb
@@ -20,7 +20,7 @@ describe Async::Children do
 	with "one child" do
 		it "can add a child" do
 			child = Async::Node.new
-			children.insert(child)
+			children.append(child)
 			
 			expect(children).not.to be(:empty?)
 		end
@@ -33,7 +33,7 @@ describe Async::Children do
 		
 		it "can't delete the child twice" do
 			child = Async::Node.new
-			children.insert(child)
+			children.append(child)
 			
 			children.delete(child)
 			

--- a/test/async/list.rb
+++ b/test/async/list.rb
@@ -26,6 +26,15 @@ describe Async::List do
 			
 			expect(list.each.map(&:value)).to be == [1, 2, 3]
 		end
+		
+		it "can't append the same item twice" do
+			item = Item.new(1)
+			list.append(item)
+			
+			expect do
+				list.append(item)
+			end.to raise_exception(ArgumentError, message: be =~ /already in a list/)
+		end
 	end
 	
 	with '#prepend' do
@@ -35,6 +44,15 @@ describe Async::List do
 			list.prepend(Item.new(3))
 			
 			expect(list.each.map(&:value)).to be == [3, 2, 1]
+		end
+		
+		it "can't prepend the same item twice" do
+			item = Item.new(1)
+			list.prepend(item)
+			
+			expect do
+				list.prepend(item)
+			end.to raise_exception(ArgumentError, message: be =~ /already in a list/)
 		end
 	end
 	

--- a/test/async/node.rb
+++ b/test/async/node.rb
@@ -273,10 +273,14 @@ describe Async::Node do
 			expect(middle.children).to be_nil
 		end
 		
+		let(:timeout) {nil}
+		
 		it 'does not stop child transient tasks' do
 			middle = Async::Node.new(node, annotation: "middle")
 			child1 = Async::Node.new(middle, transient: true, annotation: "child1")
 			child2 = Async::Node.new(middle, annotation: "child2")
+			
+			expect(middle.children).to be(:transients?)
 			
 			expect(child1).not.to receive(:stop)
 			expect(child2).to receive(:stop)


### PR DESCRIPTION
There were some minor coverage computation bugs in the covered gem. I've fixed them, and also made some minor changes to the async code to get back to 100% coverage.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
