### PR TITLE
Use a linked list for the barrier implementation.

### DIFF
--- a/lib/async/condition.rb
+++ b/lib/async/condition.rb
@@ -34,12 +34,9 @@ module Async
 		# Queue up the current fiber and wait on yielding the task.
 		# @returns [Object]
 		def wait
-			waiter = Waiter.new(Fiber.current)
-			@waiting.append(waiter)
-			
-			Fiber.scheduler.transfer
-		ensure
-			waiter.delete!
+			@waiting.stack(Waiter.new(Fiber.current)) do
+				Fiber.scheduler.transfer
+			end
 		end
 		
 		# Is any fiber waiting on this notification?

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -12,26 +12,12 @@ module Async
 	class Children < List
 		def initialize
 			super
-			
-			@size = 0
 			@transient_count = 0
 		end
-		
-		attr :size
 		
 		# Does this node have (direct) transient children?
 		def transients?
 			@transient_count > 0
-		end
-		
-		def append(node)
-			added(super)
-		end
-		
-		undef prepend
-		
-		def delete(node)
-			removed(super)
 		end
 		
 		def finished?
@@ -49,7 +35,7 @@ module Async
 				@transient_count += 1
 			end
 			
-			@size += 1
+			return super
 		end
 		
 		def removed(node)
@@ -57,7 +43,7 @@ module Async
 				@transient_count -= 1
 			end
 			
-			@size -= 1
+			return super
 		end
 	end
 	
@@ -152,7 +138,7 @@ module Async
 			return if @parent.equal?(parent)
 			
 			if @parent
-				@parent.delete_child(self)
+				@parent.remove_child(self)
 				@parent = nil
 			end
 			
@@ -173,8 +159,8 @@ module Async
 			child.set_parent(self)
 		end
 		
-		protected def delete_child(child)
-			@children.delete(child)
+		protected def remove_child(child)
+			@children.remove(child)
 			child.set_parent(nil)
 		end
 		
@@ -189,15 +175,15 @@ module Async
 		# the parent.
 		def consume
 			if parent = @parent and finished?
-				parent.delete_child(self)
+				parent.remove_child(self)
 				
 				if @children
 					@children.each do |child|
 						if child.finished?
-							delete_child(child)
+							remove_child(child)
 						else
 							# In theory we don't need to do this... because we are throwing away the list. However, if you don't correctly update the list when moving the child to the parent, it foobars the enumeration, and subsequent nodes will be skipped, or in the worst case you might start enumerating the parents nodes.
-							delete_child(child)
+							remove_child(child)
 							parent.add_child(child)
 						end
 					end

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -209,14 +209,14 @@ module Async
 			end
 		end
 		
+		# Traverse the task tree.
+		# @yields {|node, level| ...} The node and the level relative to the given root.
 		def traverse(&block)
 			return enum_for(:traverse) unless block_given?
 			
 			self.traverse_recurse(&block)
 		end
 		
-		# Traverse the tree.
-		# @yields {|node, level| ...} The node and the level relative to the given root.
 		protected def traverse_recurse(level = 0, &block)
 			yield self, level
 			

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -119,10 +119,7 @@ module Async
 			return task
 		end
 		
-		# Retrieve the current result of the task. Will cause the caller to wait until result is available. If the result was an exception, raise that exception.
-		# @raises [RuntimeError] If the task's fiber is the current fiber.
-		# @returns [Object] The final expression/result of the task's block.
-		def wait
+		def join
 			raise "Cannot wait on own fiber" if Fiber.current.equal?(@fiber)
 			
 			if running?
@@ -130,11 +127,18 @@ module Async
 				@finished.wait
 			end
 			
-			case @result
+			return @result
+		end
+		
+		# Retrieve the current result of the task. Will cause the caller to wait until result is available. If the result was an exception, raise that exception.
+		# @raises [RuntimeError] If the task's fiber is the current fiber.
+		# @returns [Object] The final expression/result of the task's block.
+		def wait
+			case result = self.join
 			when Exception
-				raise @result
+				raise result
 			else
-				return @result
+				return result
 			end
 		end
 		

--- a/test/async/barrier.rb
+++ b/test/async/barrier.rb
@@ -58,9 +58,9 @@ describe Async::Barrier do
 			expect(task1).to be(:failed?)
 			expect(task2).to be(:finished?)
 			
-			expect{barrier.wait}.to raise_exception(RuntimeError, message: be =~ /Boom/)
+			barrier.wait
 			
-			barrier.wait until barrier.empty?
+			expect{task1.wait}.to raise_exception(RuntimeError, message: be =~ /Boom/)
 			
 			expect(barrier).to be(:empty?)
 		end

--- a/test/async/children.rb
+++ b/test/async/children.rb
@@ -25,19 +25,19 @@ describe Async::Children do
 			expect(children).not.to be(:empty?)
 		end
 		
-		it "can't delete a child that hasn't been inserted" do
+		it "can't remove a child that hasn't been inserted" do
 			child = Async::Node.new
 			
-			expect{children.delete(child)}.to raise_exception(ArgumentError, message: be =~ /not in a list/)
+			expect{children.remove(child)}.to raise_exception(ArgumentError, message: be =~ /not in a list/)
 		end
 		
-		it "can't delete the child twice" do
+		it "can't remove the child twice" do
 			child = Async::Node.new
 			children.append(child)
 			
-			children.delete(child)
+			children.remove(child)
 			
-			expect{children.delete(child)}.to raise_exception(ArgumentError, message: be =~ /not in a list/)
+			expect{children.remove(child)}.to raise_exception(ArgumentError, message: be =~ /not in a list/)
 		end
 	end
 end

--- a/test/async/list.rb
+++ b/test/async/list.rb
@@ -56,12 +56,12 @@ describe Async::List do
 		end
 	end
 	
-	with '#delete' do
-		it "can delete items" do
+	with '#remove' do
+		it "can remove items" do
 			item = Item.new(1)
 			
 			list.append(item)
-			list.delete(item)
+			list.remove(item)
 			
 			expect(list.each.map(&:value)).to be(:empty?)
 		end
@@ -70,36 +70,23 @@ describe Async::List do
 			item = Item.new(1)
 			
 			list.append(item)
-			list.delete(item)
+			list.remove(item)
 			
 			expect do
-				list.delete(item)
+				list.remove(item)
 			end.to raise_exception(ArgumentError, message: be =~ /not in a list/)
 		end
 		
-		it "can delete item from the middle" do
+		it "can remove an item from the middle" do
 			item = Item.new(1)
 			
 			list.append(Item.new(2))
 			list.append(item)
 			list.append(Item.new(3))
 			
-			list.delete(item)
+			list.remove(item)
 			
 			expect(list.each.map(&:value)).to be == [2, 3]
-		end
-	end
-	
-	with 'Node#delete!' do
-		it "can't remove an item twice" do
-			item = Item.new(1)
-			
-			list.append(item)
-			item.delete!
-			
-			expect do
-				item.delete!
-			end.to raise_exception(NoMethodError)
 		end
 	end
 	
@@ -119,13 +106,37 @@ describe Async::List do
 				# This tests that enumeration is tolerant of deletion:
 				if index == 1
 					# When we are indexing child 1, it means the current node is child 0 - deleting it shouldn't break enumeration:
-					list.delete(nodes.first)
+					list.remove(nodes.first)
 				end
 				
 				index += 1
 			end
 			
 			expect(enumerated).to be == nodes
+		end
+	end
+	
+	with '#first' do
+		it "can return the first item" do
+			item = Item.new(1)
+			
+			list.append(item)
+			list.append(Item.new(2))
+			list.append(Item.new(3))
+			
+			expect(list.first).to be == item
+		end
+	end
+	
+	with '#last' do
+		it "can return the last item" do
+			item = Item.new(1)
+			
+			list.append(Item.new(2))
+			list.append(Item.new(3))
+			list.append(item)
+			
+			expect(list.last).to be == item
 		end
 	end
 end

--- a/test/async/node.rb
+++ b/test/async/node.rb
@@ -162,7 +162,7 @@ describe Async::Node do
 			expect(node.children.each.to_a).to be == bottom
 		end
 		
-		it "deletes children that are also finished" do
+		it "removes children that are also finished" do
 			middle = Async::Node.new(node)
 			bottom = Async::Node.new(middle)
 			


### PR DESCRIPTION
This simplifies the implementation and unifies the semantics with other concurrency primitives that also use a linked list.

It introduces a minor breaking change, in that `Barrier#wait` will no longer raise exceptions. Because previously the code would have been to wrap this in exception handling and retry, this should be objectively safer with no downside for existing correct code, and fix hidden issues in code which does not have retries.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.
- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
