### PR TITLE
Better support for `Fiber.set_scheduler`.

### DIFF
--- a/lib/async/reactor.rb
+++ b/lib/async/reactor.rb
@@ -21,6 +21,10 @@ module Async
 			Fiber.set_scheduler(self)
 		end
 		
+		def scheduler_close
+			self.close
+		end
+		
 		public :sleep
 	end
 end

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -34,6 +34,12 @@ module Async
 			@timers = ::Timers::Group.new
 		end
 		
+		def scheduler_close
+			self.run
+		ensure
+			self.close
+		end
+		
 		# @public Since `stable-v1`.
 		def close
 			# This is a critical step. Because tasks could be stored as instance variables, and since the reactor is (probably) going out of scope, we need to ensure they are stopped. Otherwise, the tasks will belong to a reactor that will never run again and are not stopped.

--- a/lib/kernel/async.rb
+++ b/lib/kernel/async.rb
@@ -25,6 +25,7 @@ module Kernel
 		if current = ::Async::Task.current?
 			return current.async(...)
 		else
+			# This calls Fiber.set_scheduler(self):
 			reactor = ::Async::Reactor.new
 			
 			begin

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -19,6 +19,7 @@ module Kernel
 		if task = ::Async::Task.current?
 			yield task
 		else
+			# This calls Fiber.set_scheduler(self):
 			reactor = Async::Reactor.new
 			
 			begin

--- a/test/fiber.rb
+++ b/test/fiber.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022, by Samuel Williams.
+
+require 'async/reactor'
+
+describe Fiber do
+	with '.schedule' do
+		it "can create several tasks" do
+			sequence = []
+			
+			Thread.new do
+				scheduler = Async::Scheduler.new
+				Fiber.set_scheduler(scheduler)
+				
+				Fiber.schedule do
+					3.times do |i|
+						Fiber.schedule do
+							sleep (i / 1000.0)
+							sequence << i
+						end
+					end
+				end
+			end.join
+			
+			expect(sequence).to be == [0, 1, 2]
+		end
+	end
+end


### PR DESCRIPTION
Add support for `scheduler_close` hook which is canonical for `Fiber.set_scheduler` usage, without it, the scheduled fibers won't run unless the scheduler is explicitly invoked.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
