### PR TITLE
Add `Async::Group` for straight forward list of children nodes without an associated task.

### DIFF
--- a/lib/async/group.rb
+++ b/lib/async/group.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2019-2022, by Samuel Williams.
+
+require_relative 'list'
+require_relative 'task'
+
+module Async
+	class Group < Node
+		def initialize(parent = Task.current, **options)
+			super(parent, **options)
+		end
+		
+		# Execute a child task and add it to the barrier.
+		# @asynchronous Executes the given block concurrently.
+		def async(*arguments, **options, &block)
+			task = Task.new(self, **options, &block)
+			
+			task.run(*arguments)
+			
+			return task
+		end
+		
+		# Wait for all children tasks to finish.
+		def wait
+			self.children.each do |child|
+				child.wait
+			end
+		end
+	end
+end

--- a/test/async/group.rb
+++ b/test/async/group.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022, by Samuel Williams.
+
+require 'async/group'
+require 'sus/fixtures/async'
+
+describe Async::Group do
+	include Sus::Fixtures::Async::ReactorContext
+	
+	let(:group) {subject.new}
+	
+	it 'can wait for all tasks to finish' do
+		task = group.async do
+			sleep 0.001
+		end
+		
+		expect(task.status).to be == :running
+		
+		group.wait
+		
+		expect(task.status).to be == :complete
+	end
+end


### PR DESCRIPTION
This introduces a more efficient implementation of `Async::Barrier`. It also makes me wonder if `Async::LimitedBarrier` is the right name.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
