### PR TITLE
Rename `Async::LimitedBarrier` to `Async::Waiter` based on feedback.

### DIFF
--- a/lib/async/waiter.rb
+++ b/lib/async/waiter.rb
@@ -5,7 +5,7 @@
 
 module Async
 	# A composable synchronization primitive, which allows one task to wait for a number of other tasks to complete. It can be used in conjunction with {Semaphore} and/or {Barrier}.
-	class LimitedBarrier
+	class Waiter
 		def initialize(parent: nil, finished: Async::Condition.new)
 			@finished = finished
 			@done = []

--- a/test/async/waiter.rb
+++ b/test/async/waiter.rb
@@ -1,23 +1,23 @@
 
-require 'async/limited_barrier'
+require 'async/waiter'
 require 'sus/fixtures/async'
 
-describe Async::LimitedBarrier do
+describe Async::Waiter do
 	include Sus::Fixtures::Async::ReactorContext
 	
-	let(:limited_barrier) {subject.new}
+	let(:waiter) {subject.new}
 	
 	it "can wait for a subset of tasks" do
 		3.times do
-			limited_barrier.async do
+			waiter.async do
 				sleep(rand * 0.01)
 			end
 		end
 		
-		done = limited_barrier.wait(2)
+		done = waiter.wait(2)
 		expect(done.size).to be == 2
 
-		done = limited_barrier.wait(1)
+		done = waiter.wait(1)
 		expect(done.size).to be == 1
 	end
 end


### PR DESCRIPTION
Based on feedback, renaming. It was not released yet, so this is acceptable.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
