### PR TITLE
Relax `io-event` dependency.

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 	spec.required_ruby_version = ">= 3.1.1"
 	
 	spec.add_dependency "console", "~> 1.10"
-	spec.add_dependency "io-event", "~> 1.1.0"
+	spec.add_dependency "io-event", "~> 1.1"
 	spec.add_dependency "timers", "~> 4.1"
 	
 	spec.add_development_dependency "async-rspec", "~> 1.1"


### PR DESCRIPTION
We have JRuby and Windows support in the pipeline and we need to allow for more recent releases of `io-event` gem.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
