### PR TITLE
List enumeration bug repro.

### DIFF
--- a/lib/async/list.rb
+++ b/lib/async/list.rb
@@ -159,7 +159,6 @@ module Async
 			
 			current = self
 			
-			$stderr.puts "-> each #{self}", caller
 			while true
 				validate!(current)
 				
@@ -175,8 +174,6 @@ module Async
 			end
 			
 			return self
-		ensure
-			$stderr.puts "<- each #{self}"
 		end
 		
 		# Determine whether the given node is included in the list. 
@@ -202,6 +199,12 @@ module Async
 		def last
 			unless @head.equal?(self)
 				@head
+			end
+		end
+		
+		def shift
+			if node = first
+				remove(node)
 			end
 		end
 	end

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -187,13 +187,12 @@ module Async
 			if parent = @parent and finished?
 				parent.remove_child(self)
 				
+				# If we have children, then we need to move them to our the parent if they are not finished:
 				if @children
-					@children.each do |child|
+					while child = @children.shift
 						if child.finished?
-							remove_child(child)
+							child.set_parent(nil)
 						else
-							# In theory we don't need to do this... because we are throwing away the list. However, if you don't correctly update the list when moving the child to the parent, it foobars the enumeration, and subsequent nodes will be skipped, or in the worst case you might start enumerating the parents nodes.
-							remove_child(child)
 							parent.add_child(child)
 						end
 					end

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -263,7 +263,7 @@ module Async
 			self.root.resume(@fiber)
 		end
 		
-		# Finish the current task, and all bound bound IO objects.
+		# Finish the current task, moving any children to the parent.
 		def finish!
 			# Allow the fiber to be recycled.
 			@fiber = nil

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -430,8 +430,9 @@ describe Async::Task do
 				end
 				
 				parent.wait
-				parent.stop
 				expect(parent).to be(:complete?)
+				parent.stop
+				expect(parent).to be(:stopped?)
 				expect(transient).to be(:running?)
 			end.wait
 		end

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -414,6 +414,27 @@ describe Async::Task do
 			
 			expect(items).to be == [1, 2]
 		end
+		
+		it "can stop a child task with transient children" do
+			parent = child = transient = nil
+			
+			reactor.run do |task|
+				parent = task.async do |task|
+					transient = task.async(transient: true) do
+						sleep(1)
+					end
+					
+					child = task.async do
+						sleep(1)
+					end
+				end
+				
+				parent.wait
+				parent.stop
+				expect(parent).to be(:complete?)
+				expect(transient).to be(:running?)
+			end.wait
+		end
 	end
 	
 	with '#sleep' do


### PR DESCRIPTION
It looks like there is a linked list enumeration bug that triggers when transient tasks move up the task tree and cause consume to be called while iterating the task children.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
