### PR TITLE
Improve the robustness of the reactor interrupt test.

### DIFF
--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -128,15 +128,19 @@ describe Async::Reactor do
 		it "can stop reactor from different thread" do
 			events = Thread::Queue.new
 			
+			reactor = self.reactor
+			
 			thread = Thread.new do
 				if events.pop
-					reactor.interrupt
+					2.times do
+						reactor.interrupt
+						sleep(0.01)
+					end
 				end
 			end
 			
 			reactor.async do
 				events << true
-				
 				# Wait to be interrupted:
 				sleep
 			end


### PR DESCRIPTION
The reactor interrupt mechanism is not a guaranteed robust mechanism. Interrupts can be missed if the interrupt is received before entering sleep. Making this more reliable in the future might be useful.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
