### PR TITLE
Allow assigning to semaphore limit.

### DIFF
--- a/lib/async/semaphore.rb
+++ b/lib/async/semaphore.rb
@@ -28,6 +28,25 @@ module Async
 		# The tasks waiting on this semaphore.
 		attr :waiting
 		
+		# Allow setting the limit. This is useful for cases where the semaphore is used to limit the number of concurrent tasks, but the number of tasks is not known in advance or needs to be modified.
+		#
+		# On increasing the limit, some tasks may be immediately resumed. On decreasing the limit, some tasks may execute until the count is < than the limit. 
+		#
+		# @parameter limit [Integer] The new limit.
+		def limit= limit
+			difference = limit - @limit
+			@limit = limit
+			
+			# We can't suspend 
+			if difference > 0
+				difference.times do
+					break unless node = @waiting.first
+					
+					node.resume
+				end
+			end
+		end
+		
 		# Is the semaphore currently acquired?
 		def empty?
 			@count.zero?


### PR DESCRIPTION
`async-pool` would benefit from being able to resize and increase the maximum limit, but to do this, increasing (or decreasing) the limit on a semaphore should be a well defined operation. The semantics are:

- On increasing the limit, some tasks may be immediately resumed.
- On decreasing the limit, some tasks may execute until the count is < than the limit.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
