### PR TITLE
Test segfault

### DIFF
--- a/examples/bugs/write_lock.rb
+++ b/examples/bugs/write_lock.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+# This bug only generally shows up on Linux, when using io_uring, as it has more fine-grained locking. The issue is that `puts` can acquire and release a write lock, and if one thread releases that lock while the reactor on the waitq thread is closing, it can call `unblock` with `@selector = nil` which fails or causes odd behaviour.
+
+require_relative '../../lib/async'
+
+def wait_for_interrupt(thread_index, repeat)
+	sequence = []
+	
+	events = Thread::Queue.new
+	reactor = Async::Reactor.new
+	
+	thread = Thread.new do
+		if events.pop
+			puts "#{thread_index}+#{repeat} Sending Interrupt!"
+			reactor.interrupt
+		end
+	end
+	
+	reactor.async do
+		events << true
+		puts "#{thread_index}+#{repeat} Reactor ready!"
+		
+		# Wait to be interrupted:
+		sleep(1)
+		
+		puts "#{thread_index}+#{repeat} Missing interrupt!"
+	end
+	
+	reactor.run
+	
+	thread.join
+end
+
+100.times.map do |thread_index|
+	Thread.new do
+		1000.times do |repeat|
+			wait_for_interrupt(thread_index, repeat)
+		end
+	end
+end.each(&:join)

--- a/test-segfault.rb
+++ b/test-segfault.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+
+require_relative 'lib/async'
+
+def wait_for_interrupt(thread_index, repeat)
+	sequence = []
+	
+	events = Thread::Queue.new
+	reactor = Async::Reactor.new
+	
+	thread = Thread.new do
+		if events.pop
+			puts "#{thread_index}+#{repeat} Sending Interrupt!"
+			reactor.interrupt
+		end
+	end
+	
+	reactor.async do
+		events << true
+		puts "#{thread_index}+#{repeat} Reactor ready!"
+		
+		# Wait to be interrupted:
+		sleep(1)
+		
+		puts "#{thread_index}+#{repeat} Missing interrupt!"
+	end
+	
+	reactor.run
+	
+	thread.join
+end
+
+32.times.map do |thread_index|
+	Thread.new do
+		100.times do |repeat|
+			wait_for_interrupt(thread_index, repeat)
+		end
+	end
+end.each(&:join)

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -63,4 +63,28 @@ describe Async::Scheduler do
 			expect(duration).to be <= 0.1
 		end
 	end
+	
+	with '#interrupt' do
+		it "can interrupt a closed scheduler" do
+			scheduler = Async::Scheduler.new
+			scheduler.close
+			scheduler.interrupt
+		end
+	end
+	
+	with '#block' do
+		it "can block and unblock the scheduler after closing" do
+			scheduler = Async::Scheduler.new
+			
+			fiber = Fiber.new do
+				scheduler.block(:test, nil)
+			end
+			
+			fiber.transfer
+			
+			expect do
+				scheduler.close
+			end.to raise_exception(RuntimeError, message: be =~ /Closing scheduler with blocked operations/)
+		end
+	end
 end


### PR DESCRIPTION
There is a race condition which can cause a segfault/`rb_bug` in very rare cases. It is hard to reproduce. I added a repro script that only works on Linux, and only once in every 3-4 runs, only when using `io_uring`. I'll think about whether I can add a specific test case.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
