### PR TITLE
Ensure all tasks are terminated before closing scheduler.

### DIFF
--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -231,6 +231,8 @@ module Async
 			@children&.each do |child|
 				child.terminate
 			end
+			
+			return @children.nil?
 		end
 		
 		# Attempt to stop the current node immediately, including all non-transient children. Invokes {#stop_children} to stop all children.

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -42,8 +42,10 @@ module Async
 		
 		# @public Since `stable-v1`.
 		def close
-			# This is a critical step. Because tasks could be stored as instance variables, and since the reactor is (probably) going out of scope, we need to ensure they are stopped. Otherwise, the tasks will belong to a reactor that will never run again and are not stopped.
-			self.terminate
+			# It's critical to stop all tasks. Otherwise they might be holding on to resources which are never closed/released correctly.
+			until self.terminate
+				self.run_once
+			end
 			
 			Kernel::raise "Closing scheduler with blocked operations!" if @blocked > 0
 			

--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -6,7 +6,9 @@
 
 require 'async'
 require 'sus/fixtures/async'
+
 require 'benchmark/ips'
+require 'tempfile'
 
 describe Async::Reactor do
 	let(:reactor) {subject.new}
@@ -31,6 +33,17 @@ describe Async::Reactor do
 			reactor.close
 			
 			expect(reactor).to be(:closed?)
+		end
+		
+		it "terminates transient tasks" do
+			task = reactor.async(transient: true) do
+				sleep
+			ensure
+				sleep
+			end
+			
+			reactor.run_once
+			reactor.close
 		end
 	end
 	


### PR DESCRIPTION
It's possible for some tasks to remain after the scheduler is closed. If those tasks performed asynchronous IO, which took a write lock, this could lead to subsequent deadlocks, e.g. https://github.com/socketry/io-event/issues/54

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
