### PR TITLE
Don't allow event loop to be interrupted at any time.

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -257,10 +257,13 @@ module Async
 			initial_task = self.async(...) if block_given?
 			
 			@interrupted = false
+			thread = Thread.current
 			
-			while self.run_once
-				if @interrupted
-					break
+			Thread.handle_interrupt(Exception => :never) do
+				while self.run_once
+					if @interrupted || thread.pending_interrupt?
+						break
+					end
 				end
 			end
 			

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -259,7 +259,7 @@ module Async
 			@interrupted = false
 			thread = Thread.current
 			
-			Thread.handle_interrupt(Exception => :never) do
+			Thread.handle_interrupt(SignalException => :never) do
 				while self.run_once
 					if @interrupted || thread.pending_interrupt?
 						break

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -257,11 +257,10 @@ module Async
 			initial_task = self.async(...) if block_given?
 			
 			@interrupted = false
-			thread = Thread.current
 			
-			Thread.handle_interrupt(SignalException => :never) do
+			Thread.handle_interrupt(Exception => :on_blocking) do
 				while self.run_once
-					if @interrupted || thread.pending_interrupt?
+					if @interrupted
 						break
 					end
 				end

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -258,9 +258,10 @@ module Async
 			
 			@interrupted = false
 			
-			Thread.handle_interrupt(Exception => :on_blocking) do
+			# In theory, we could use Exception here to be a little bit safer, but we've only shown the case for SignalException to be a problem, so let's not over-engineer this.
+			Thread.handle_interrupt(SignalException => :never) do
 				while self.run_once
-					if @interrupted
+					if @interrupted || Thread.pending_interrupt?
 						break
 					end
 				end


### PR DESCRIPTION
Don't allow the event loop thread to be interrupted at any time, which can cause odd behaviour and/or deadlocks.

Fixes #220.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
