### PR TITLE
Guide: LimitedBarrier was renamed to Waiter

### DIFF
--- a/guides/asynchronous-tasks/readme.md
+++ b/guides/asynchronous-tasks/readme.md
@@ -143,20 +143,23 @@ end
 
 ### Waiting for the First N Tasks
 
-Occasionally, you may need to just wait for the first task (or first several tasks) to complete. You can use a combination of {ruby Async::LimitedBarrier} and {ruby Async::Barrier} for controlling this:
+Occasionally, you may need to just wait for the first task (or first several tasks) to complete. You can use a combination of {ruby Async::Waiter} and {ruby Async::Barrier} for controlling this:
 
 ```ruby
-barrier = Async::Barrier.new(parent: barrier)
+waiter = Async::Waiter.new(parent: barrier)
 
 Async do
 	jobs.each do |job|
-		barrier.async do
+		waiter.async do
 			# ... process job ...
 		end
 	end
 	
 	# Wait for the first two jobs to complete:
-	done = barrier.wait(2)
+	done = waiter.wait(2)
+	
+	# You may use the barrier to stop the remaining jobs
+	barrier.stop
 end
 ```
 


### PR DESCRIPTION
The guide was still talking about the LimitedBarrier even though it was renamed to Waiter in https://github.com/socketry/async/pull/196.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
