### PR TITLE
Delegate to `Fiber#annotate` where possible.

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "console", "~> 1.10"
 	spec.add_dependency "io-event", "~> 1.1"
 	spec.add_dependency "timers", "~> 4.1"
+	spec.add_dependency "fiber-annotate"
 	
 	spec.add_development_dependency "bake-test"
 	spec.add_development_dependency "bake-test-external"

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -96,6 +96,22 @@ module Async
 			@fiber&.backtrace(*arguments)
 		end
 		
+		def annotate(annotation, &block)
+			if @fiber
+				@fiber.annotate(annotation, &block)
+			else
+				super
+			end
+		end
+		
+		def annotation
+			if @fiber
+				@fiber.annotation
+			else
+				super
+			end
+		end
+		
 		def to_s
 			"\#<#{self.description} (#{@status})>"
 		end
@@ -309,7 +325,7 @@ module Async
 		end
 		
 		def schedule(&block)
-			@fiber = Fiber.new do
+			@fiber = Fiber.new(annotation: self.annotation) do
 				set!
 				
 				begin

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -17,6 +17,32 @@ describe Async::Task do
 		super
 	end
 	
+	with '#annotate' do
+		it "can annotate the current task that has not started yet" do
+			task = Async::Task.new(reactor) do |task|
+				sleep
+			end
+			
+			task.annotate("Hello World")
+			
+			expect(task.annotation).to be == "Hello World"
+		end
+		
+		it "can annotate the current task that has started" do
+			task = Async::Task.new(reactor) do |task|
+				task.annotate("Hello World")
+				
+				sleep
+			end
+			
+			expect(task.fiber).to be_nil
+			
+			task.run
+			
+			expect(task.fiber.annotation).to be == "Hello World"
+		end
+	end
+	
 	with '.yield' do
 		it "can yield back to scheduler" do
 			state = nil


### PR DESCRIPTION
It would be better if fiber annotations were not Async-specific.

I introduced [`fiber-annotate` gem](https://github.com/ioquatix/fiber-annotate) which provides such an interface.

This PR uses that interface instead of the internal annotation mechanism where possible. We should eventually deprecate and remove it.

For more context, see <https://bugs.ruby-lang.org/issues/19056>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
