### PR TITLE
Fix handling of stop stopping the stopping task.

### DIFF
--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -439,6 +439,28 @@ describe Async::Task do
 			end
 		end
 		
+		it "can stop the parent task which stops the stopping task" do
+			condition = Async::Notification.new
+			
+			reactor.run do |task|
+				task.async do
+					condition.wait
+					task.stop
+				end
+				
+				task.async do
+					sleep
+				end
+
+				# NOTE: Hangs only if this second task is added
+				task.async do
+					sleep
+				end
+				
+				condition.signal
+			end
+		end
+		
 		it "should not remove running task" do
 			top_task = middle_task = bottom_task = nil
 			


### PR DESCRIPTION
Fixes <https://github.com/socketry/async/issues/158>.

It was possible to raise `Stop` on a different fiber, and if that fiber was a parent of the task that was invoking `stop_children`, it was possible to kill that task mid-iteration, which would prevent stopping the remaining children.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
