### PR TITLE
Strip device suffix before resolving hostname.

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -156,6 +156,9 @@ module Async
 		
 		# @asynchronous May be non-blocking..
 		def address_resolve(hostname)
+			# On some platforms, hostnames may contain a device-specific suffix (e.g. %en0). We need to strip this before resolving.
+			# See <https://github.com/socketry/async/issues/180> for more details.
+			hostname = hostname.split("%", 2).first
 			::Resolv.getaddresses(hostname)
 		end
 		

--- a/test/async/scheduler/address.rb
+++ b/test/async/scheduler/address.rb
@@ -15,5 +15,23 @@ describe Async::Scheduler do
 			
 			expect(addresses).not.to be(:empty?)
 		end
+		
+		it "can resolve ipv4 addresses" do
+			address = Addrinfo.getaddrinfo("127.0.0.1", "80").first
+			
+			expect(address.ipv4?).to be == true
+		end
+		
+		it "can resolve ipv6 addresses" do
+			address = Addrinfo.getaddrinfo("::1", "80").first
+			
+			expect(address.ipv6?).to be == true
+		end
+		
+		it "can resolve ipv6 addresses with device suffix" do
+			address = Addrinfo.getaddrinfo("::1%lo0", "80").first
+			
+			expect(address.ipv6?).to be == true
+		end
 	end
 end


### PR DESCRIPTION
This is an attempt to fix #180 and <https://github.com/socketry/async-http/issues/107>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
