### PR TITLE
Ensure transient tasks are correctly terminated.

### DIFF
--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -40,7 +40,20 @@ describe Async::Reactor do
 				sleep
 			end
 			
+			expect(reactor.run_once).to be == false
+			expect(reactor).to be(:finished?)
+			reactor.close
+		end
+		
+		it "terminates transient tasks with nested tasks" do
+			task = reactor.async(transient: true) do |parent|
+				parent.async do |child|
+					sleep(1)
+				end
+			end
+			
 			reactor.run_once
+			expect(reactor).to be(:finished?)
 			reactor.close
 		end
 		


### PR DESCRIPTION
Fixes <https://github.com/socketry/async/issues/244>.

Top level transient tasks are a bit odd. The event loop is considered already `finished?` and thus won't execute a single iteration. However, in order to terminate the event loop, any child tasks need to be stopped.

The following program causes a hang:

```ruby
Async(transient:true) do
  Async{sleep 1}
end
```

1. The top level task is created and executes, starting the child task.
2. The child task starts sleeping.
3. The event loop is considered finished because the top level task is transient.
4. The `Scheduler#close` method is invoked, which enters the terminate loop.
5. `Task#stop` is invoked on the top level task which stops the child task by raising and exception, but itself is not stopped yet. Raising an exception transfers to the child task.
6. Because `run_once` considers the scheduler is finished, it does not resume the parent task.
7. It continues to try and stop the top level task, but won't resume it (even thought it's in the ready list).
8. Infinite loop is achieved.

The fix, I think, is to avoid checking `self.finished?` when performing the termination loop. Tests added based on the original report.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
