### PR TITLE
Fix Markdown syntax highlighting marker

### DIFF
--- a/guides/best-practices/readme.md
+++ b/guides/best-practices/readme.md
@@ -83,4 +83,4 @@ class Packages
 		end
 	end
 end
-~~~
+```


### PR DESCRIPTION
This fixes a wrong output in the docs: there was a `~~~` where there shouldn't be.

## Types of Changes

- Maintenance.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
