### PR TITLE
Follow-up barrier in scope docs fix

### DIFF
--- a/lib/async/barrier.md
+++ b/lib/async/barrier.md
@@ -7,9 +7,9 @@ A synchronization primitive, which allows one task to wait for a number of other
 require 'async'
 require 'async/barrier'
 
+barrier = Async::Barrier.new
 Sync do
 	Console.logger.info("Barrier Example: sleep sort.")
-	barrier = Async::Barrier.new
 	
 	# Generate an array of 10 numbers:
 	numbers = 10.times.map{rand(10)}


### PR DESCRIPTION
This makes the same change as #253 but in this file: ensure block may not have access to the `barrier` local.

## Types of Changes

- Bug fix.
- Maintenance.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
