### PR TITLE
Better handling of interrupted flag.

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -208,6 +208,7 @@ module Async
 		end
 		
 		# Run one iteration of the event loop.
+		# Does not handle interrupts.
 		# @parameter timeout [Float | Nil] The maximum timeout, or if nil, indefinite.
 		# @returns [Boolean] Whether there is more work to do.
 		def run_once(timeout = nil)
@@ -253,20 +254,35 @@ module Async
 			return true
 		end
 		
+		# Checks and clears the interrupted state of the scheduler.
+		# @returns [Boolean] Whether the reactor has been interrupted.
+		private def interrupted?
+			if @interrupted
+				@interrupted = false
+				return true
+			end
+			
+			if Thread.pending_interrupt?
+				return true
+			end
+			
+			return false
+		end
+		
 		# Run the reactor until all tasks are finished. Proxies arguments to {#async} immediately before entering the loop, if a block is provided.
 		def run(...)
 			Kernel::raise ClosedError if @selector.nil?
 			
 			initial_task = self.async(...) if block_given?
 			
-			@interrupted = false
-			
 			# In theory, we could use Exception here to be a little bit safer, but we've only shown the case for SignalException to be a problem, so let's not over-engineer this.
 			Thread.handle_interrupt(SignalException => :never) do
-				while self.run_once
-					if @interrupted || Thread.pending_interrupt?
-						break
-					end
+				while true
+					# If we are interrupted, we need to exit:
+					break if self.interrupted?
+					
+					# If we are finished, we need to exit:
+					break unless self.run_once
 				end
 			end
 			

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -67,6 +67,21 @@ describe Async::Scheduler do
 	end
 	
 	with '#interrupt' do
+		it "can interrupt a scheduler while it's not running" do
+			scheduler = Async::Scheduler.new
+			finished = false
+			
+			scheduler.run do |task|
+				# Interrupting here should mean that the sleep below never finishes:
+				scheduler.interrupt
+				
+				scheduler.yield
+				finished = true
+			end
+			
+			expect(finished).to be == false
+		end
+		
 		it "can interrupt a closed scheduler" do
 			scheduler = Async::Scheduler.new
 			scheduler.close

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -72,7 +72,7 @@ describe Async::Scheduler do
 			finished = false
 			
 			scheduler.run do |task|
-				# Interrupting here should mean that the sleep below never finishes:
+				# Interrupting here should mean that the yield below never returns:
 				scheduler.interrupt
 				
 				scheduler.yield


### PR DESCRIPTION
The interrupted flag needs to be handled more carefully.

In particular, it should only be cleared when it's been acted on, and we also need to check that the scheduler hasn't been interrupted before entering the select which can sleep indefinitely.

We need to add tests, but I haven't written them yet.

Fixes <https://github.com/socketry/async/issues/258>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
