### PR TITLE
add test for timeout while getting from stdin

### DIFF
--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -596,6 +596,22 @@ describe Async::Task do
 			expect(state).to be == :timeout
 		end
 		
+		it "will timeout while getting from stdin" do
+			error = nil
+			
+			reactor.async do |task|
+				begin
+					task.with_timeout(0.1) { STDIN.gets }
+				rescue StandardError => e
+					error = e
+				end
+			end
+			
+			reactor.run
+			
+			expect(error).to be_a(Async::TimeoutError)
+		end
+
 		it "won't timeout if execution completes in time" do
 			state = nil
 			

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -601,7 +601,7 @@ describe Async::Task do
 			
 			reactor.async do |task|
 				begin
-					task.with_timeout(0.1) { STDIN.gets }
+					task.with_timeout(0.1) {STDIN.gets}
 				rescue Async::TimeoutError => error
 				  # Ignore.
 				end

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -602,8 +602,8 @@ describe Async::Task do
 			reactor.async do |task|
 				begin
 					task.with_timeout(0.1) { STDIN.gets }
-				rescue StandardError => e
-					error = e
+				rescue Async::TimeoutError => error
+				  # Ignore.
 				end
 			end
 			


### PR DESCRIPTION
Added a test to shows that with_timeout() does not return Async::Timeout() if timing out while getting from stdin.

The test can be run with:
```
% bundle exec sus test/async/task.rb:599
🏁 Finished in 103.3ms; 9.682 assertions per second.
🐇 No slow tests found! Well done!

🤔 Failed assertions:
describe Async::Task with #with_timeout it will timeout while getting from stdin test/async/task.rb:599
	expect #<Errno::ENOENT: No such file or directory @ io_fillbuf - fd:0 <STDIN>> to
		be is_a? Async::TimeoutError
			✗ assertion failed test/async/task.rb:612
```

## Types of Changes
- Added a test

## Contribution
- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
