### PR TITLE
test gets in task

### DIFF
--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -836,4 +836,16 @@ describe Async::Task do
 			end
 		end
 	end
+
+	it "can gets in a task" do
+		IO.pipe do |input, output|
+		  Async do
+				Async do
+					expect(input.gets).to be == "hello\n"
+				end
+				output.puts "hello"
+			end
+		end
+	end
+
 end


### PR DESCRIPTION
Adds a test for #256

Test can be run with:
```
% bundle exec sus test/async/task.rb:812                             
1 passed out of 1 total (1 assertions)
🏁 Finished in 723.0µs; 1383.126 assertions per second.
🐇 No slow tests found! Well done!
```

It succeeds on Mac, but I suspect it will hang on Windows, as it's essentially the example from #256.

## Types of Changes
- added a test

## Contribution
- [x] I added tests for my changes.
- [x] I tested my changes locally. (not on Windows though..)
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).