### PR TITLE
If a task returns an exception value, do not raise it in #wait.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -190,7 +190,7 @@ module Async
 				@finished.wait
 			end
 			
-			if @result.is_a?(Exception)
+			if @status == :failed
 				raise @result
 			else
 				return @result

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -711,6 +711,13 @@ describe Async::Task do
 			expect(error_task).to be(:finished?)
 			expect(innocent_task).to be(:finished?)
 		end
+
+		it "will not raise exception values returned by the task" do
+			error = StandardError.new
+			task = reactor.async { error }
+			expect(task.wait).to be == error
+			expect(task.result).to be == error
+		end
 	end
 	
 	with '#result' do


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

## Notes

If a task returns an exception value (without raising it), `#wait` raises it.

```ruby
require 'async'
Sync do
	t = Async do
		StandardError.new
	end
	t.wait # raises StandardError!
end
```

Seems like something that would rarely happen, but it happened to me with an `assert_raises` at the end of a task (apparently, it returns the exception that was raised).
