### PR TITLE
Fix handling of `TimeoutError` in `io_wait`.

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -171,17 +171,11 @@ module Async
 			
 			if timeout
 				timer = @timers.after(timeout) do
-					fiber.raise(TimeoutError)
+					fiber.transfer
 				end
 			end
 			
-			# Console.logger.info(self, "-> io_wait", fiber, io, events)
-			events = @selector.io_wait(fiber, io, events)
-			# Console.logger.info(self, "<- io_wait", fiber, io, events)
-			
-			return events
-		rescue TimeoutError
-			return false
+			return @selector.io_wait(fiber, io, events)
 		ensure
 			timer&.cancel
 		end

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -597,11 +597,12 @@ describe Async::Task do
 		end
 		
 		it "will timeout while getting from stdin" do
+			input, output = IO.pipe
 			error = nil
 			
 			reactor.async do |task|
 				begin
-					task.with_timeout(0.1) {STDIN.gets}
+					task.with_timeout(0.1) {input.gets}
 				rescue Async::TimeoutError => error
 				  # Ignore.
 				end
@@ -610,6 +611,9 @@ describe Async::Task do
 			reactor.run
 			
 			expect(error).to be_a(Async::TimeoutError)
+		ensure
+			input.close
+			output.close
 		end
 
 		it "won't timeout if execution completes in time" do

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -596,12 +596,13 @@ describe Async::Task do
 			expect(state).to be == :timeout
 		end
 		
-		it "will timeout while getting from stdin" do
+		it "will timeout while getting from input" do
 			input, output = IO.pipe
 			error = nil
 			
 			reactor.async do |task|
 				begin
+					# This can invoke `io_wait`, which previously had `rescue TimeoutError`, causing the timeout to be ignored.
 					task.with_timeout(0.1) {input.gets}
 				rescue Async::TimeoutError => error
 				  # Ignore.


### PR DESCRIPTION
`TimeoutError` was used internally to handle timeouts. However, with the updated design of `io-event`, this is no longer needed, so let's simplify the design. This also avoids consuming user-raised exceptions of this class.

Fixes <https://github.com/socketry/async/pull/266>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
