### PR TITLE
Allow Interrupt to retry the run loop after issuing #stop.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -20,6 +20,7 @@ jobs:
           - ubuntu
         
         ruby:
+          - "3.1"
           - "3.2"
           - "ruby-head"
     

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -89,11 +89,13 @@ describe Async::Scheduler do
 		end
 		
 		it "can interrupt a scheduler from a different thread" do
-			scheduler = Async::Scheduler.new
 			finished = false
 			sleeping = Thread::Queue.new
 			
 			thread = Thread.new do
+				scheduler = Async::Scheduler.new
+				Fiber.set_scheduler(scheduler)
+				
 				scheduler.run do |task|
 					sleeping.push(true)
 					sleep
@@ -105,13 +107,14 @@ describe Async::Scheduler do
 						finished = true
 					end
 				end
-			rescue Interrupt
-				# Ignore.
+			# rescue Interrupt
+			# 	# Ignore.
 			end
 			
 			expect(sleeping.pop).to be == true
 			expect(finished).to be == false
 			
+			binding.irb
 			thread.raise(Interrupt)
 			
 			expect(sleeping.pop).to be == true

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -87,6 +87,41 @@ describe Async::Scheduler do
 			scheduler.close
 			scheduler.interrupt
 		end
+		
+		it "can interrupt a scheduler from a different thread" do
+			scheduler = Async::Scheduler.new
+			finished = false
+			sleeping = Thread::Queue.new
+			
+			thread = Thread.new do
+				scheduler.run do |task|
+					sleeping.push(true)
+					sleep
+				ensure
+					begin
+						sleeping.push(true)
+						sleep
+					ensure
+						finished = true
+					end
+				end
+			rescue Interrupt
+				# Ignore.
+			end
+			
+			expect(sleeping.pop).to be == true
+			expect(finished).to be == false
+			
+			thread.raise(Interrupt)
+			
+			expect(sleeping.pop).to be == true
+			expect(finished).to be == false
+			
+			thread.raise(Interrupt)
+			thread.join
+			
+			expect(finished).to be == true
+		end
 	end
 	
 	with '#block' do

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -114,7 +114,6 @@ describe Async::Scheduler do
 			expect(sleeping.pop).to be == true
 			expect(finished).to be == false
 			
-			binding.irb
 			thread.raise(Interrupt)
 			
 			expect(sleeping.pop).to be == true


### PR DESCRIPTION
Ctrl-C should allow for graceful clean-up. This behaviour is probably also more compatible with Async 1.x.

Fixes https://github.com/socketry/async/issues/291

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
