### PR TITLE
Don't enable `io_write` hook on Ruby < 3.3.1 as it's buggy.

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,6 +29,9 @@ jobs:
           - os: ubuntu
             ruby: "3.3"
             selector: URing
+          - os: ubuntu
+            ruby: "head"
+            selector: URing
     
     steps:
     - uses: actions/checkout@v4

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -212,7 +212,7 @@ module Async
 				timer&.cancel
 			end
 			
-			if RUBY_ENGINE != "ruby" || RUBY_VERSION >= "3.3.0"
+			if RUBY_ENGINE != "ruby" || RUBY_VERSION >= "3.3.1"
 				def io_write(io, buffer, length, offset = 0)
 					fiber = Fiber.current
 					

--- a/test/io.rb
+++ b/test/io.rb
@@ -74,4 +74,18 @@ describe IO do
 			expect(input.wait_readable(0)).to be_nil
 		end
 	end
+	
+	describe '/dev/null' do
+		# Ruby < 3.3.1 will fail this test with the `io_write` scheduler hook enabled, as it will try to io_wait on /dev/null which will fail on some platforms (kqueue).
+		it "can write to /dev/null" do
+			out = File.open("/dev/null", "w")
+			
+			# Needs to write about 8,192 bytes to trigger the internal flush:
+			1000.times do
+				out.puts "Hello World!"
+			end
+		ensure
+			out.close
+		end
+	end
 end


### PR DESCRIPTION
Fixes <https://github.com/socketry/async/issues/301>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
