### PR TITLE
Fix compatibility with quoting change.

### DIFF
--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -129,7 +129,7 @@ describe Async::Reactor do
 				reactor.print_hierarchy(output, backtrace: true)
 				lines = output.string.lines
 				
-				expect(lines).to have_value(be =~ /in `sleep'/)
+				expect(lines).to have_value(be =~ /in .*sleep'/)
 				
 				child.stop
 			end


### PR DESCRIPTION
Ruby head changes the formatting of the backtrace.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
