### PR TITLE
Better handling of interrupts during stop/terminate.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -209,7 +209,7 @@ module Async
 		def stop(later = false)
 			if self.stopped?
 				# If we already stopped this task... don't try to stop it again:
-				return
+				return stopped!
 			end
 			
 			# If the fiber is alive, we need to stop it:
@@ -304,7 +304,7 @@ module Async
 			stopped = false
 			
 			begin
-				# We are bnot running, but children might be so we should stop them:
+				# We are not running, but children might be so we should stop them:
 				stop_children(true)
 			rescue Stop
 				stopped = true


### PR DESCRIPTION
After playing around with `async-container` and `async-service`, I identified some cases where unusual error messages would show up. It turned out to be the delivery of multiple interrupt signals within a short time-frame, causing interrupts the be raise while interrupts were being processed. We try to prevent interrupts from causing chaos during termination/close operations.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
