### PR TITLE
Introduce `Scheduler#load` and `Async::Idler` for load shedding and saturation.

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.10"
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "io-event", "~> 1.5"
+	spec.add_dependency "io-event", "~> 1.5", ">= 1.5.1"
 	spec.add_dependency "timers", "~> 4.1"
 end

--- a/async.gemspec
+++ b/async.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.10"
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "io-event", "~> 1.1"
+	spec.add_dependency "io-event", "~> 1.5"
 	spec.add_dependency "timers", "~> 4.1"
 end

--- a/examples/load/test.rb
+++ b/examples/load/test.rb
@@ -1,0 +1,27 @@
+#!/usr/bin/env ruby
+
+require_relative '../../lib/async'
+require_relative '../../lib/async/idler'
+
+Async do
+	idler = Async::Idler.new(0.8)
+	
+	Async do
+		while true
+			idler.async do
+				$stdout.write '.'
+				while true
+					sleep 0.1
+				end
+			end
+		end
+	end
+	
+	scheduler = Fiber.scheduler
+	while true
+		load = scheduler.load
+
+		$stdout.write "\nLoad: #{load} "
+		sleep 1.0
+	end
+end

--- a/lib/async/idler.rb
+++ b/lib/async/idler.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+module Async
+	class Idler
+		def initialize(maximum_load = 0.8, backoff: 0.01, parent: nil)
+			@maximum_load = maximum_load
+			@backoff = backoff
+			@parent = parent
+		end
+		
+		def async(*arguments, parent: (@parent or Task.current), **options, &block)
+			wait
+			
+			# It is crucial that we optimistically execute the child task, so that we prevent a tight loop invoking this method from consuming all available resources.
+			parent.async(*arguments, **options, &block)
+		end
+		
+		def wait
+			scheduler = Fiber.scheduler
+			backoff = nil
+			
+			while true
+				load = scheduler.load 
+				break if load < @maximum_load
+				
+				if backoff
+					sleep(backoff)
+					backoff *= 2.0
+				else
+					scheduler.yield
+					backoff = @backoff
+				end
+			end
+		end
+	end
+end

--- a/test/async/idler.rb
+++ b/test/async/idler.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2018-2023, by Samuel Williams.
+
+require 'async/idler'
+require 'sus/fixtures/async'
+
+require 'chainable_async'
+
+describe Async::Idler do
+	include Sus::Fixtures::Async::ReactorContext
+	let(:idler) {subject.new(0.5)}
+	
+	it 'can schedule tasks up to the desired load' do
+		# Generate the load:
+		Async do
+			while true
+				idler.async do
+					while true
+						sleep 0.1
+					end
+				end
+			end
+		end
+		
+		# This test must be longer than the test window...
+		sleep 1.1
+		
+		# Verify that the load is within the desired range:
+		expect(Fiber.scheduler.load).to be_within(0.1).of(0.5)
+	end
+	
+	it_behaves_like ChainableAsync
+end


### PR DESCRIPTION
Introduce `Scheduler#load` which is a 1-second load average. This load average can be used to detect overload conditions in the event loop. In addition, introduce `Async::Idler` which will schedule tasks up to a given `maximum_load`.

Typical use cases include connection load shedding:

```ruby
scheduler = Fiber.scheduler
while true
  server.wait_readable 
  if scheduler.load < 0.8
    handle_connection(server.accept)
  end
end
```

Request load shedding:

```ruby
while request = client.read_request
  if scheduler.load > 0.95
    return too_many_requests #429
  end
  # ...handle request...
```

And load saturation:

```ruby
idler = Async::Idler.new(0.95)
jobs.each do |job|
  idler.async do # schedule as many jobs concurrently up to 95% loading
    job.process
  end
end
```

While I'm confident the interface is good enough, there is a small chance that I've not anticipated some critical use case. We may introduce changes to this interface. `Async::Idler` is unlikely to change.

Fixes <https://github.com/socketry/async/issues/277>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
