### PR TITLE
Stop children even if the current task is deferring stop.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -218,6 +218,9 @@ module Async
 			if @defer_stop == false
 				# Don't stop now... but update the state so we know we need to stop later.
 				@defer_stop = true
+				
+				stop_children(false)
+				
 				return false
 			end
 			


### PR DESCRIPTION
Defer stop does not mean "don't stop". It means there is some code which should ignore stop for a little while and the stop, kind of like an asynchronous ensure block. Therefore, I don't think we should prevent it from propagating to child tasks.

In particular, if you have a server task that is handling one or more child tasks (responses), those tasks should be stopped.

The alternative is to make `defer_stop` parameteric, but I'm trying to avoid increasing the complexity of this interface.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
