### PR TITLE
Prefer `IO::Event::Timers`.

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -27,6 +27,5 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", ["~> 1.25", ">= 1.25.2"]
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "io-event", ["~> 1.5", ">= 1.5.1"]
-	spec.add_dependency "timers", "~> 4.1"
+	spec.add_dependency "io-event", "~> 1.6"
 end

--- a/benchmark/timers/after_0.rb
+++ b/benchmark/timers/after_0.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require 'benchmark/ips'
+
+require 'timers'
+require 'io/event/timers'
+
+Benchmark.ips do |benchmark|
+	benchmark.time = 1
+	benchmark.warmup = 1
+	
+	benchmark.report("Timers::Group") do |count|
+		timers = Timers::Group.new
+		
+		while count > 0
+			timers.after(0) {count -= 1}
+			timers.fire
+		end
+	end
+	
+	benchmark.report("IO::Event::Timers") do |count|
+		timers = IO::Event::Timers.new
+		
+		while count > 0
+			timers.after(0) {count -= 1}
+			timers.fire
+		end
+	end
+	
+	benchmark.compare!
+end

--- a/benchmark/timers/after_cancel.rb
+++ b/benchmark/timers/after_cancel.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require 'benchmark/ips'
+
+require 'timers'
+require 'io/event/timers'
+
+Benchmark.ips do |benchmark|
+	benchmark.time = 1
+	benchmark.warmup = 1
+	
+	benchmark.report("Timers::Group") do |count|
+		timers = Timers::Group.new
+		
+		while count > 0
+			timer = timers.after(0) {}
+			timer.cancel
+			count -= 1
+		end
+		
+		timers.fire
+	end
+	
+	benchmark.report("IO::Event::Timers") do |count|
+		timers = IO::Event::Timers.new
+		
+		while count > 0
+			timer = timers.after(0) {}
+			timer.cancel!
+			count -= 1
+		end
+		
+		timers.fire
+	end
+	
+	benchmark.compare!
+end

--- a/benchmark/timers/after_n.rb
+++ b/benchmark/timers/after_n.rb
@@ -1,0 +1,39 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require 'benchmark/ips'
+
+require 'timers'
+require 'io/event/timers'
+
+Benchmark.ips do |benchmark|
+	benchmark.time = 1
+	benchmark.warmup = 1
+	
+	benchmark.report("Timers::Group") do |count|
+		timers = Timers::Group.new
+		
+		while count > 0
+			timers.after(0) {}
+			count -= 1
+		end
+		
+		timers.fire
+	end
+	
+	benchmark.report("IO::Event::Timers") do |count|
+		timers = IO::Event::Timers.new
+		
+		while count > 0
+			timers.after(0) {}
+			count -= 1
+		end
+		
+		timers.fire
+	end
+	
+	benchmark.compare!
+end

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 # ![Async](logo.svg)
 
-Async is a composable asynchronous I/O framework for Ruby based on [io-event](https://github.com/socketry/io-event) and
-[timers](https://github.com/socketry/timers).
+Async is a composable asynchronous I/O framework for Ruby based on [io-event](https://github.com/socketry/io-event).
 
 > "Lately I've been looking into `async`, as one of my projects –
 > [tus-ruby-server](https://github.com/janko/tus-ruby-server) – would really benefit from non-blocking I/O. It's really


### PR DESCRIPTION
Minor performance improvement as demonstrated by attached benchmarks.

```
samuel@Sakura ~/D/s/a/b/timers (use-io-event-timers)> bundle exec ./after_0.rb 
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
       Timers::Group    65.144k i/100ms
   IO::Event::Timers   130.653k i/100ms
Calculating -------------------------------------
       Timers::Group    658.748k (± 0.5%) i/s -    716.584k in   1.087824s
   IO::Event::Timers      1.304M (± 0.2%) i/s -      1.307M in   1.002237s

Comparison:
   IO::Event::Timers:  1303616.9 i/s
       Timers::Group:   658747.8 i/s - 1.98x  slower

samuel@Sakura ~/D/s/a/b/timers (use-io-event-timers)> bundle exec ./after_n.rb
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
       Timers::Group    13.982k i/100ms
   IO::Event::Timers    21.496k i/100ms
Calculating -------------------------------------
       Timers::Group    154.925k (± 0.8%) i/s -    167.784k in   1.083072s
   IO::Event::Timers    230.674k (± 0.3%) i/s -    236.456k in   1.025078s

Comparison:
   IO::Event::Timers:   230673.5 i/s
       Timers::Group:   154925.4 i/s - 1.49x  slower

samuel@Sakura ~/D/s/a/b/timers (use-io-event-timers)> bundle exec ./after_cancel.rb
ruby 3.3.0 (2023-12-25 revision 5124f9ac75) [arm64-darwin23]
Warming up --------------------------------------
       Timers::Group   101.792k i/100ms
   IO::Event::Timers   232.860k i/100ms
Calculating -------------------------------------
       Timers::Group      1.006M (± 1.0%) i/s -      1.018M in   1.011619s
   IO::Event::Timers      2.544M (± 3.2%) i/s -      2.561M in   1.008093s

Comparison:
   IO::Event::Timers:  2543646.0 i/s
       Timers::Group:  1006322.4 i/s - 2.53x  slower
```

This was always on the cards, I just hadn't gotten around to it.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
