### PR TITLE
Correct typos

### DIFF
--- a/guides/asynchronous-tasks/readme.md
+++ b/guides/asynchronous-tasks/readme.md
@@ -83,7 +83,7 @@ Async do
 end
 ```
 
-Instead of taking 6 seconds, this program takes 3 seconds in total. The main loop executes rapidly creating 3 child tasks, and then each child task sleeps for 1, 2 and 3 seconds respectively before printing "Hello World".
+Instead of taking 6 seconds, this program takes 3 seconds in total. The main loop executes, rapidly creating 3 child tasks, and then each child task sleeps for 1, 2 and 3 seconds respectively before printing "Hello World".
 
 ```mermaid
 graph LR
@@ -104,7 +104,7 @@ Async do
 	
 	# Reduce (wait for and merge the results)
 	average = posts_size.wait / users_size.wait
-	puts "#{users_size.wait} users created #{ruby Average} posts on average."
+	puts "#{users_size.wait} users created #{average} posts on average."
 end
 ```
 

--- a/guides/compatibility/readme.md
+++ b/guides/compatibility/readme.md
@@ -19,14 +19,13 @@ Because it was designed with the interfaces available in Ruby 2.x, the following
 
 ### Main
 
-The `main` branch of async is compatible with Ruby 3.0.2+, and partially compatible with TruffleRuby. JRuby is currently incompatble.
+The `main` branch of async is compatible with Ruby 3.1.1+, and partially compatible with TruffleRuby. JRuby is currently incompatble.
 
 Because it was designed with the interfaces available in Ruby 3.x, it supports the fiber scheduler which provides transparent concurrency.
 
 - {ruby Async::Task} uses {ruby Fiber#transfer} for scheduling so it is compatible with all other usage of Fiber.
 - {ruby Async::Reactor} implements the Fiber scheduler interface and is compatible with a wide range of non-blocking operations, including DNS, {ruby Process.wait}, etc.
 - External C libraries that use blocking operations may still block.
-- Ruby <= 3.0.2 has some bugs in its non-blocking thread primitives. These should be fixed in 3.0.3+.
 
 ## Rails
 

--- a/guides/event-loop/readme.md
+++ b/guides/event-loop/readme.md
@@ -44,7 +44,7 @@ Most methods of the reactor and related tasks are not thread-safe, so you'd typi
 
 ### Embedding Reactors
 
-{ruby Async::Scheduler#run} will run until the reactor runs out of work to do. To run a single iteration of the reactor, use {ruby Async::Scheduler#run_once}
+{ruby Async::Scheduler#run} will run until the reactor runs out of work to do. To run a single iteration of the reactor, use {ruby Async::Scheduler#run_once}.
 
 ~~~ ruby
 require 'async'

--- a/guides/getting-started/readme.md
+++ b/guides/getting-started/readme.md
@@ -34,7 +34,7 @@ A selector is part of the implementation of an event loop which is responsible f
 
 A reactor is a specific implementation of the scheduler interface, which includes an event loop and selector, and is responsible for managing the execution of fibers.
 
-## Creating an Asynchronous Tasks
+## Creating an Asynchronous Task
 
 The main entry point for creating tasks is the {ruby Kernel#Async} method. Because this method is defined on `Kernel`, it's available in all parts of your program.
 
@@ -46,17 +46,17 @@ Async do |task|
 end
 ~~~
 
-An {ruby Async::Task} runs using a {ruby Fiber} and blocking operations e.g. `sleep`, `read`, `write` yield control until the operation can complete. When a blocking operation yields control, it means another fiber can execute, giving the illusion of simultaneous execution.
+A {ruby Async::Task} runs using a {ruby Fiber} and blocking operations e.g. `sleep`, `read`, `write` yield control until the operation can complete. When a blocking operation yields control, it means another fiber can execute, giving the illusion of simultaneous execution.
 
 ### When should I use `Async`?
 
 You should use `Async` when you desire explicit concurrency in your program. That means you want to run multiple tasks at the same time, and you want to be able to wait for the results of those tasks.
 
-- You should use `Async` when you want to perform network operations, such as HTTP requests, or database queries concurrently.
+- You should use `Async` when you want to perform network operations concurrently, such as HTTP requests or database queries.
 - You should use `Async` when you want to process independent requests concurrently, such as a web server.
 - You should use `Async` when you want to handle multiple connections concurrently, such as a chat server.
 
-You should consider the boundary around your program and the request handling. For example, one task per operation, request or conection, is usually appropriate.
+You should consider the boundary around your program and the request handling. For example, one task per operation, request or connection, is usually appropriate.
 
 ### Waiting for Results
 
@@ -164,7 +164,7 @@ Async do
 end
 ```
 
-Unfortunately, some libraries do not integrate well with the fiber scheduler, either they are blocking, processor bound, use thread locals for execution state. To uses these libraries, you may be able to use a background thread.
+Unfortunately, some libraries do not integrate well with the fiber scheduler: either they are blocking, processor bound, or use thread locals for execution state. To use these libraries, you may be able to use a background thread.
 
 ```ruby
 Async do


### PR DESCRIPTION
I love how readable and straightforward the documentation is, thank you for keeping it simple!

I noticed some typos and I'm submitting them for your consideration.

Also, the gemspec in `main` requires 3.1.1, not 3.0.x, and has for some time. So I updated the docs regarding that as well.

## Types of Changes

Documentation changes only.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).