### PR TITLE
Propagate interrupts when exiting event loop.

### DIFF
--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -90,6 +90,7 @@ describe Async::Scheduler do
 		
 		it "can interrupt a scheduler from a different thread" do
 			finished = false
+			interrupted = false
 			sleeping = Thread::Queue.new
 			
 			thread = Thread.new do
@@ -107,12 +108,13 @@ describe Async::Scheduler do
 						finished = true
 					end
 				end
-			# rescue Interrupt
-			# 	# Ignore.
+			rescue Interrupt
+				interrupted = true
 			end
 			
 			expect(sleeping.pop).to be == true
 			expect(finished).to be == false
+			expect(interrupted).to be == false
 			
 			thread.raise(Interrupt)
 			
@@ -123,6 +125,7 @@ describe Async::Scheduler do
 			thread.join
 			
 			expect(finished).to be == true
+			expect(interrupted).to be == true
 		end
 		
 		it "ignores interrupts during termination" do


### PR DESCRIPTION
Probably fixes <https://github.com/socketry/async/issues/321>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
