### PR TITLE
Waiter#async: pass options to parent

### DIFF
--- a/lib/async/waiter.rb
+++ b/lib/async/waiter.rb
@@ -15,8 +15,8 @@ module Async
 		
 		# Execute a child task and add it to the waiter.
 		# @asynchronous Executes the given block concurrently.
-		def async(parent: (@parent or Task.current), &block)
-			parent.async do |task|
+		def async(parent: (@parent or Task.current), **options, &block)
+			parent.async(**options) do |task|
 				yield(task)
 			ensure
 				@done << task

--- a/test/async/waiter.rb
+++ b/test/async/waiter.rb
@@ -42,4 +42,14 @@ describe Async::Waiter do
 			waiter.wait
 		end.to raise_exception(RuntimeError)
 	end
+
+	with 'barrier parent' do
+		let(:barrier) { Async::Barrier.new }
+		let(:waiter) { subject.new(parent: barrier) }
+
+		it "passes annotation to barrier" do
+			expect(barrier).to receive(:async).with(annotation: 'waited upon task')
+			waiter.async(annotation: 'waited upon task') { }
+		end
+	end
 end


### PR DESCRIPTION
This allows `Async::Waiter#async` to pass an annotation to its parent's `#async`.