### PR TITLE
Restore error logging.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -187,6 +187,7 @@ module Async
 				schedule do
 					@block.call(self, *arguments)
 				rescue => error
+					# I'm not completely happy with this overhead, but the alternative is to not log anything which makes debugging extremely difficult. Maybe we can introduce a debug wrapper which adds extra logging.
 					if @finished.nil?
 						Console::Event::Failure.for(error).emit("Task may have ended with unhandled exception.", severity: :warn)
 					# else

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -189,8 +189,8 @@ module Async
 				rescue => error
 					if @finished.nil?
 						Console::Event::Failure.for(error).emit("Task may have ended with unhandled exception.", severity: :warn)
-					else
-						Console::Event::Failure.for(error).emit(self, severity: :debug)
+					# else
+					# 	Console::Event::Failure.for(error).emit(self, severity: :debug)
 					end
 					
 					raise


### PR DESCRIPTION
After experimenting with the $DEBUG error logging, I found the developer UX was significantly worse. So I'd like to restore this more verbose logging.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
