### PR TITLE
Fiber refinement

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,0 +1,14 @@
+{
+  "lib/async/*.rb": {
+    "alternate": "test/async/{}.rb"
+  },
+  "lib/kernel/*.rb": {
+    "alternate": "test/kernel/{}.rb"
+  },
+  "test/async/*.rb": {
+    "alternate": "lib/async/{}.rb"
+  },
+  "test/kernel/*.rb": {
+    "alternate": "lib/kernel/{}.rb"
+  }
+}

--- a/benchmark/monkey_patch_vs_refinement.rb
+++ b/benchmark/monkey_patch_vs_refinement.rb
@@ -1,0 +1,48 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Patrik Wenger.
+
+require 'benchmark/ips'
+
+GC.disable
+
+Fiber.attr_accessor :foo
+
+module FiberWithBar
+	refine Fiber do
+		attr_accessor :bar
+	end
+end
+
+using FiberWithBar
+
+Benchmark.ips do |benchmark|
+	benchmark.time = 1
+	benchmark.warmup = 1
+	
+	benchmark.report("monkey patch") do |count|
+		while count > 0
+			Fiber.new do
+				count -= 1
+
+				Fiber.current.foo = :baz
+				fail if Fiber.current.foo != :baz
+			end.resume
+		end
+	end
+	
+	benchmark.report("refinement") do |count|
+		while count > 0
+			Fiber.new do
+				count -= 1
+
+				Fiber.current.bar = :baz
+				fail if Fiber.current.bar != :baz
+			end.resume
+		end
+	end
+	
+	benchmark.compare!
+end

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -13,9 +13,15 @@ require 'console/event/failure'
 require_relative 'node'
 require_relative 'condition'
 
-Fiber.attr_accessor :async_task
-
 module Async
+	module FiberWithAsyncTask
+		refine Fiber do
+			attr_accessor :async_task
+		end
+	end
+
+	using FiberWithAsyncTask
+
 	# Raised when a task is explicitly stopped.
 	class Stop < Exception
 		# Used to defer stopping the current task until later.


### PR DESCRIPTION
According to the new benchmark script, performance stays the same:

```
$ ruby monkey_patch_vs_refinement.rb
ruby 3.3.3 (2024-06-12 revision f1c7b6f435) [x86_64-linux]
Warming up --------------------------------------
        monkey patch    26.336k i/100ms
          refinement    27.581k i/100ms
Calculating -------------------------------------
        monkey patch    304.481k (± 8.2%) i/s -    316.032k in   1.045685s
          refinement    303.663k (± 5.6%) i/s -    303.391k in   1.002361s

Comparison:
        monkey patch:   304480.8 i/s
          refinement:   303663.4 i/s - same-ish: difference falls within error
```

If you'd rather have `Fiber#async_task` available to anyone, I'm okay with you closing this PR. It just occured to me that a refinement could be used in this case.