### PR TITLE
Graceful shutdown

### DIFF
--- a/lib/async/idler.rb
+++ b/lib/async/idler.rb
@@ -41,7 +41,8 @@ module Async
 			backoff = nil
 			
 			while true
-				load = scheduler.load 
+				load = scheduler.load
+				
 				break if load < @maximum_load
 				
 				if backoff

--- a/test/async/idler.rb
+++ b/test/async/idler.rb
@@ -13,6 +13,8 @@ describe Async::Idler do
 	let(:idler) {subject.new(0.5)}
 	
 	it 'can schedule tasks up to the desired load' do
+		expect(Fiber.scheduler.load).to be < 0.1
+		
 		# Generate the load:
 		Async do
 			while true
@@ -24,7 +26,7 @@ describe Async::Idler do
 			end
 		end
 		
-		# This test must be longer than the test window...
+		# This test must be longer than the idle calculation window (1s)...
 		sleep 1.1
 		
 		# Verify that the load is within the desired range:

--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -42,6 +42,10 @@ describe Async::Reactor do
 			
 			expect(reactor.run_once).to be == false
 			expect(reactor).to be(:finished?)
+			
+			# Kick the task into the ensure block:
+			reactor.stop
+			
 			reactor.close
 		end
 		

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -188,14 +188,18 @@ describe Async::Scheduler do
 		it "exits gracefully" do
 			state = nil
 			
-			Async do |task|
+			Sync do |task|
 				task.async(transient: true) do
 					state = :sleeping
-					 # Never come back:
+					# Never come back:
 					Fiber.scheduler.transfer
 				ensure
 					state = :ensure
-					2.times{Fiber.scheduler.yield}
+					# Yoyo but eventually exit:
+					5.times do
+						Fiber.scheduler.yield
+					end
+					
 					state = :finished
 				end
 			end

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -183,4 +183,24 @@ describe Async::Scheduler do
 			end.to raise_exception(RuntimeError, message: be =~ /Closing scheduler with blocked operations/)
 		end
 	end
+	
+	with "transient tasks" do
+		it "exits gracefully" do
+			state = nil
+			
+			Async do |task|
+				task.async(transient: true) do
+					state = :sleeping
+					 # Never come back:
+					Fiber.scheduler.transfer
+				ensure
+					state = :ensure
+					2.times{Fiber.scheduler.yield}
+					state = :finished
+				end
+			end
+			
+			expect(state).to be == :finished
+		end
+	end
 end


### PR DESCRIPTION
In general, users should expect ensure blocks to work normally (sequentially).

Transient tasks do not keep the reactor alive. e.g.

```ruby
Async do
  Async(transient: true) do
    sleep
  ensure
    sleep 1; $stderr.write "."
  end
end
```

Before this PR, the above program will not print any dot. After this PR, the program will print a dot. This allows transient tasks to clean up more robustly. The downside is, a badly behaving transient task may stall the event loop from exiting. However, `Ctrl-C` will interrupt the event loop again and cause it to exit.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
