### PR TITLE
Graceful shutdown

### DIFF
--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -34,6 +34,14 @@ module Async
 			empty?
 		end
 		
+		def adjust_transient_count(transient)
+			if transient
+				@transient_count += 1
+			else
+				@transient_count -= 1
+			end
+		end
+		
 		private
 		
 		def added(node)
@@ -108,6 +116,14 @@ module Async
 		# parent task from finishing.
 		def transient?
 			@transient
+		end
+		
+		protected def transient=(value)
+			if @transient != value
+				@transient = value
+				
+				@parent&.children&.adjust_transient_count(value)
+			end
 		end
 		
 		# Annotate the node with a description.

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -34,6 +34,9 @@ module Async
 			empty?
 		end
 		
+		# Adjust the number of transient children, assuming it has changed.
+		#
+		# @parameter transient [Boolean] Whether to increment or decrement the transient count.
 		def adjust_transient_count(transient)
 			if transient
 				@transient_count += 1

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -36,6 +36,8 @@ module Async
 		
 		# Adjust the number of transient children, assuming it has changed.
 		#
+		# Despite being public, this is not intended to be called directly. It is used internally by {Node#transient=}.
+		#
 		# @parameter transient [Boolean] Whether to increment or decrement the transient count.
 		def adjust_transient_count(transient)
 			if transient
@@ -121,7 +123,12 @@ module Async
 			@transient
 		end
 		
-		protected def transient=(value)
+		# Change the transient state of the node.
+		#
+		# A transient node is not considered when determining if a node is finished, and propagates up if the parent is consumed.
+		#
+		# @parameter value [Boolean] Whether the node is transient.
+		def transient=(value)
 			if @transient != value
 				@transient = value
 				

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -296,7 +296,7 @@ module Async
 			Kernel.raise "Running scheduler on non-blocking fiber!" unless Fiber.blocking?
 			
 			# If we are finished, we stop the task tree and exit:
-			if self.finished?
+			if @children.nil?
 				return false
 			end
 			
@@ -398,9 +398,11 @@ module Async
 			initial_task = self.async(...) if block_given?
 			
 			self.run_loop do
-				unless self.finished?
-					run_once!
+				if self.finished?
+					self.stop
 				end
+				
+				run_once!
 			end
 			
 			return initial_task

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -262,6 +262,9 @@ module Async
 			
 			# If the fiber is alive, we need to stop it:
 			if @fiber&.alive?
+				# As the task is now exiting, we want to ensure the event loop continues to execute until the task finishes.
+				self.transient = false
+				
 				if self.current?
 					# If the fiber is current, and later is `true`, we need to schedule the fiber to be stopped later, as it's currently invoking `stop`:
 					if later
@@ -276,7 +279,7 @@ module Async
 					begin
 						# There is a chance that this will stop the fiber that originally called stop. If that happens, the exception handling in `#stopped` will rescue the exception and re-raise it later.
 						Fiber.scheduler.raise(@fiber, Stop)
-					rescue FiberError
+					rescue FiberError => error
 						# In some cases, this can cause a FiberError (it might be resumed already), so we schedule it to be stopped later:
 						Fiber.scheduler.push(Stop::Later.new(self))
 					end

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -176,7 +176,7 @@ module Async
 		
 		alias complete? completed?
 		
-		# @attribute [Symbol] The status of the execution of the fiber, one of `:initialized`, `:running`, `:complete`, `:stopped` or `:failed`.
+		# @attribute [Symbol] The status of the execution of the task, one of `:initialized`, `:running`, `:complete`, `:stopped` or `:failed`.
 		attr :status
 		
 		# Begin the execution of the task.

--- a/test/async/children.rb
+++ b/test/async/children.rb
@@ -40,4 +40,22 @@ describe Async::Children do
 			expect{children.remove(child)}.to raise_exception(ArgumentError, message: be =~ /not in a list/)
 		end
 	end
+	
+	with "transient children" do
+		let(:parent) {Async::Node.new}
+		let(:children) {parent.children}
+		
+		it "can add a transient child" do
+			child = Async::Node.new(parent, transient: true)
+			expect(children).to be(:transients?)
+			
+			child.transient = false
+			expect(children).not.to be(:transients?)
+			expect(parent).not.to be(:finished?)
+			
+			child.transient = true
+			expect(children).to be(:transients?)
+			expect(parent).to be(:finished?)
+		end
+	end
 end

--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -40,7 +40,7 @@ describe Async::Reactor do
 				sleep
 			end
 			
-			expect(reactor.run_once).to be == false
+			expect(reactor.run_once(0)).to be == false
 			expect(reactor).to be(:finished?)
 			
 			# Kick the task into the ensure block:

--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -40,11 +40,8 @@ describe Async::Reactor do
 				sleep
 			end
 			
-			expect(reactor.run_once(0)).to be == false
 			expect(reactor).to be(:finished?)
-			
-			# Kick the task into the ensure block:
-			reactor.stop
+			expect(reactor.run_once(0)).to be == true
 			
 			reactor.close
 		end

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -187,9 +187,10 @@ describe Async::Scheduler do
 	with "transient tasks" do
 		it "exits gracefully" do
 			state = nil
+			child_task = nil
 			
 			Sync do |task|
-				task.async(transient: true) do
+				child_task = task.async(transient: true) do
 					state = :sleeping
 					# Never come back:
 					Fiber.scheduler.transfer
@@ -205,6 +206,7 @@ describe Async::Scheduler do
 			end
 			
 			expect(state).to be == :finished
+			expect(child_task).not.to be(:transient?)
 		end
 	end
 end


### PR DESCRIPTION
This expands on the current revised implementation in order to allow transient tasks to gracefully shutdown without being forcefully terminated.

On stopping a transient task, it is converted to a non-transient task, which prevents the event loop from exiting. This keeps the event loop alive.

If a task creates new tasks while it's finishing, those will be handled according to the existing logic.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
