### PR TITLE
Ensure that defer_stop resets state.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -304,19 +304,23 @@ module Async
 			# - false: defer_stop has been called and we are not stopping.
 			# - true: defer_stop has been called and we will stop when exiting the block.
 			if @defer_stop.nil?
-				# If we are not deferring stop already, we can defer it now:
-				@defer_stop = false
-				
 				begin
+					# If we are not deferring stop already, we can defer it now:
+					@defer_stop = false
+					
 					yield
 				rescue Stop
 					# If we are exiting due to a stop, we shouldn't try to invoke stop again:
 					@defer_stop = nil
 					raise
 				ensure
+					defer_stop = @defer_stop
+					
+					# We need to ensure the state is reset before we exit the block:
+					@defer_stop = nil
+					
 					# If we were asked to stop, we should do so now:
-					if @defer_stop
-						@defer_stop = nil
+					if defer_stop
 						raise Stop, "Stopping current task (was deferred)!"
 					end
 				end

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -909,6 +909,18 @@ describe Async::Task do
 			child_task.stop
 			expect(child_task).to be(:stopped?)
 		end
+		
+		it "can defer stop and exit normally" do
+			child_task = reactor.async do |task|
+				task.defer_stop do
+					# Nothing.
+				end
+			end
+			
+			reactor.run_once(0)
+			
+			expect(child_task.stop_deferred?).to be == nil
+		end
 	end
 	
 	with "failing task" do


### PR DESCRIPTION
Exiting normally from `#defer_stop` was leaving `@defer_stop = false` - which caused extra issues when later invoking `#stop` or `#defer_stop` again.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
