### PR TITLE
Better handling of bare `Async` and `Sync` blocks when a scheduler is defined.

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -345,7 +345,7 @@ module Async
 		# Check if there is a task defined for the current fiber.
 		# @returns [Interface(:async) | Nil]
 		def self.current?
-			Fiber.current.async_task
+			Fiber.current.async_task || Fiber[:async_task]
 		end
 		
 		# @returns [Boolean] Whether this task is the currently executing task.
@@ -411,6 +411,8 @@ module Async
 		
 		def schedule(&block)
 			@fiber = Fiber.new(annotation: self.annotation) do
+				Fiber[:async_task] = self
+				
 				begin
 					completed!(yield)
 				rescue Stop

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -67,6 +67,13 @@ module Async
 			Fiber.scheduler.transfer
 		end
 		
+		# Run the given block of code in a task, asynchronously, in the given scheduler.
+		def self.run(scheduler, *arguments, **options, &block)
+			self.new(scheduler, **options, &block).tap do |task|
+				task.run(*arguments)
+			end
+		end
+		
 		# Create a new task.
 		# @parameter reactor [Reactor] the reactor this task will run within.
 		# @parameter parent [Task] the parent task.

--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -345,7 +345,7 @@ module Async
 		# Check if there is a task defined for the current fiber.
 		# @returns [Interface(:async) | Nil]
 		def self.current?
-			Fiber.current.async_task || Fiber[:async_task]
+			Fiber.current.async_task
 		end
 		
 		# @returns [Boolean] Whether this task is the currently executing task.
@@ -411,8 +411,6 @@ module Async
 		
 		def schedule(&block)
 			@fiber = Fiber.new(annotation: self.annotation) do
-				Fiber[:async_task] = self
-				
 				begin
 					completed!(yield)
 				rescue Stop

--- a/lib/kernel/async.rb
+++ b/lib/kernel/async.rb
@@ -24,6 +24,10 @@ module Kernel
 	def Async(...)
 		if current = ::Async::Task.current?
 			return current.async(...)
+		elsif scheduler = Fiber.scheduler
+			task = ::Async::Task.new(scheduler, transient: true)
+			task.run(...)
+			return task
 		else
 			# This calls Fiber.set_scheduler(self):
 			reactor = ::Async::Reactor.new

--- a/lib/kernel/async.rb
+++ b/lib/kernel/async.rb
@@ -25,9 +25,7 @@ module Kernel
 		if current = ::Async::Task.current?
 			return current.async(...)
 		elsif scheduler = Fiber.scheduler
-			task = ::Async::Task.new(scheduler, transient: true)
-			task.run(...)
-			return task
+			::Async::Task.run(scheduler, ...)
 		else
 			# This calls Fiber.set_scheduler(self):
 			reactor = ::Async::Reactor.new

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -18,6 +18,10 @@ module Kernel
 	def Sync(&block)
 		if task = ::Async::Task.current?
 			yield task
+		elsif scheduler = Fiber.scheduler
+			task = ::Async::Task.new(scheduler, transient: true)
+			task.run(&block)
+			return task.wait
 		else
 			# This calls Fiber.set_scheduler(self):
 			reactor = Async::Reactor.new

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -19,9 +19,7 @@ module Kernel
 		if task = ::Async::Task.current?
 			yield task
 		elsif scheduler = Fiber.scheduler
-			task = ::Async::Task.new(scheduler, transient: true)
-			task.run(&block)
-			return task.wait
+			::Async::Task.run(scheduler, &block).wait
 		else
 			# This calls Fiber.set_scheduler(self):
 			reactor = Async::Reactor.new

--- a/readme.md
+++ b/readme.md
@@ -35,6 +35,10 @@ Please see the [project documentation](https://socketry.github.io/async/) for mo
 
 Please see the [project releases](https://socketry.github.io/async/releases/index) for all releases.
 
+### Next
+
+  - [Better Handling of Async and Sync in Nested Fibers](https://socketry.github.io/async/releases/index#better-handling-of-async-and-sync-in-nested-fibers)
+
 ## See Also
 
   - [async-http](https://github.com/socketry/async-http) — Asynchronous HTTP client/server.

--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,24 @@
+# Changes
+
+## Next
+
+### Better Handling of Async and Sync in Nested Fibers
+
+Interleaving bare fibers within `Async` and `Sync` blocks should not cause problems, but it presents a number of issues in the current implementation. Tracking the parent-child relationship between tasks, when they are interleaved with bare fibers, is difficult. The current implementation assumes that if there is no parent task, then it should create a new reactor. This is not always the case, as the parent task might not be visible due to nested Fibers. As a result, `Async` will create a new reactor, trying to stop the existing one, causing major internal consistency issues.
+
+I encountered this issue when trying to use `Async` within a streaming response in Rails. The `protocol-rack` [uses a normal fiber to wrap streaming responses](https://github.com/socketry/protocol-rack/blob/cb1ca44e9deadb9369bdb2ea03416556aa927c5c/lib/protocol/rack/body/streaming.rb#L24-L28), and if you try to use `Async` within it, it will create a new reactor, causing the server to lock up.
+
+Ideally, `Async` and `Sync` helpers should work when any `Fiber.scheduler` is defined. Right now, it's unrealistic to expect `Async::Task` to work in any scheduler, but at the very least, the following should work:
+
+```ruby
+reactor = Async::Reactor.new # internally calls Fiber.set_scheduler
+
+# This should run in the above reactor, rather than creating a new one.
+Async do
+  puts "Hello World"
+end
+```
+
+In order to do this, bare `Async` and `Sync` blocks should use `Fiber.scheduler` as a parent if possible.
+
+See <https://github.com/socketry/async/pull/340> for more details.

--- a/test/async/reactor.rb
+++ b/test/async/reactor.rb
@@ -268,19 +268,38 @@ describe Async::Reactor do
 		end
 	end
 	
-	it "reuses existing scheduler" do
-		# Assign the scheduler:
-		reactor = self.reactor
-		
-		# Re-use the previous scheduler:
-		state = nil
-		Async do
-			state = :started
+	with 'Kernel.Async' do
+		it "reuses existing scheduler" do
+			# Assign the scheduler:
+			reactor = self.reactor
+			
+			# Re-use the previous scheduler:
+			state = nil
+			Async do
+				state = :started
+			end
+			
+			reactor.run
+			
+			expect(state).to be == :started
 		end
-		
-		reactor.run
-		
-		expect(state).to be == :started
+	end
+	
+	with 'Kernel.Sync' do
+		it "reuses existing scheduler" do
+			# Assign the scheduler:
+			reactor = self.reactor
+			
+			# Re-use the previous scheduler:
+			state = nil
+			Sync do |task|
+				state = :started
+			end
+			
+			reactor.run
+			
+			expect(state).to be == :started
+		end
 	end
 end
 

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -17,7 +17,7 @@ describe Async::Task do
 	let(:reactor) {Async::Reactor.new}
 	
 	after do
-		reactor.close
+		Fiber.set_scheduler(nil)
 	end
 	
 	with '#annotate' do

--- a/test/fiber.rb
+++ b/test/fiber.rb
@@ -32,6 +32,27 @@ describe Fiber do
 			
 			expect(error).to be_a(Async::Stop)
 		end
+		
+		it "can nest child tasks within a resumed fiber" do
+			skip_unless_minimum_ruby_version("3.3.4")
+			
+			variable = Async::Variable.new
+			error = nil
+			
+			Sync do |task|
+				child_task = task.async do
+					Fiber.new do
+						Async do
+							variable.value
+						end.wait
+					end.resume
+				end
+				
+				expect(child_task).to be(:running?)
+				
+				variable.value = true
+			end
+		end
 	end
 	
 	with '.schedule' do


### PR DESCRIPTION
Nested fibers can cause issues with Async, when spawning child tasks within them. I was affected by this issue when trying to create a streaming response from a Rails controller, using the `proc do |stream| ... Async{....} end` style response body. However, `protocol-rack` [uses a normal fiber to wrap streaming responses](https://github.com/socketry/protocol-rack/blob/cb1ca44e9deadb9369bdb2ea03416556aa927c5c/lib/protocol/rack/body/streaming.rb#L24-L28) and the child Async task has no parent, causing it to try and create a new event loop... meltdown ensues.

Ideally, `Async` and `Sync` helpers should work when any `Fiber.scheduler` is defined. Right now, it's unrealistic to expect `Async::Task` to work in any scheduler, but at the very least, the following should work:

```ruby
reactor = Async::Reactor.new # internally calls Fiber.set_scheduler

# This should run in the above reactor:
Async do
  puts "Hello World"
end
```

In order to do this, bare `Async` and `Sync` blocks should use `Fiber.scheduler` as a parent if possible.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
