### PR TITLE
Kernel#Sync: pass annotation: keyword to newly created Reactor

### DIFF
--- a/gems.rb
+++ b/gems.rb
@@ -20,7 +20,7 @@ group :maintenance, optional: true do
 end
 
 group :test do
-	gem "sus", "~> 0.29", ">= 0.29.1"
+	gem "sus", "~> 0.31"
 	gem "covered"
 	gem "decode"
 	gem "rubocop"

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -17,7 +17,11 @@ module Kernel
 	# @asynchronous Will block until given block completes executing.
 	def Sync(*arguments, **options, &block)
 		if task = ::Async::Task.current?
-			yield task
+			if annotation = options[:annotation]
+				task.annotate(annotation) { yield task }
+			else
+				yield task
+			end
 		elsif scheduler = Fiber.scheduler
 			::Async::Task.run(scheduler, &block).wait
 		else

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -18,7 +18,7 @@ module Kernel
 	def Sync(annotation: nil, &block)
 		if task = ::Async::Task.current?
 			if annotation
-				task.annotate(annotation) { yield task }
+				task.annotate(annotation) {yield task}
 			else
 				yield task
 			end

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -15,9 +15,9 @@ module Kernel
 	#
 	# @public Since `stable-v1`.
 	# @asynchronous Will block until given block completes executing.
-	def Sync(*arguments, **options, &block)
+	def Sync(annotation: nil, &block)
 		if task = ::Async::Task.current?
-			if annotation = options[:annotation]
+			if annotation
 				task.annotate(annotation) { yield task }
 			else
 				yield task
@@ -29,7 +29,13 @@ module Kernel
 			reactor = Async::Reactor.new
 			
 			begin
-				return reactor.run(*arguments, **options, finished: ::Async::Condition.new, &block).wait
+				options = {
+					finished: ::Async::Condition.new
+				}
+
+				options[:annotation] = annotation if annotation
+
+				return reactor.run(**options, &block).wait
 			ensure
 				Fiber.set_scheduler(nil)
 			end

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -29,13 +29,7 @@ module Kernel
 			reactor = Async::Reactor.new
 			
 			begin
-				options = {
-					finished: ::Async::Condition.new
-				}
-
-				options[:annotation] = annotation if annotation
-
-				return reactor.run(**options, &block).wait
+				return reactor.run(annotation: annotation, finished: ::Async::Condition.new, &block).wait
 			ensure
 				Fiber.set_scheduler(nil)
 			end

--- a/lib/kernel/sync.rb
+++ b/lib/kernel/sync.rb
@@ -15,7 +15,7 @@ module Kernel
 	#
 	# @public Since `stable-v1`.
 	# @asynchronous Will block until given block completes executing.
-	def Sync(&block)
+	def Sync(*arguments, **options, &block)
 		if task = ::Async::Task.current?
 			yield task
 		elsif scheduler = Fiber.scheduler
@@ -25,7 +25,7 @@ module Kernel
 			reactor = Async::Reactor.new
 			
 			begin
-				return reactor.run(finished: ::Async::Condition.new, &block).wait
+				return reactor.run(*arguments, **options, finished: ::Async::Condition.new, &block).wait
 			ensure
 				Fiber.set_scheduler(nil)
 			end

--- a/test/kernel/async.rb
+++ b/test/kernel/async.rb
@@ -17,6 +17,10 @@ describe Kernel do
 			Async(transient: true) do |task|
 				expect(task).to be(:transient?)
 			end
+
+			Async(annotation: 'foobar') do |task|
+				expect(task.annotation).to be == 'foobar'
+			end
 		end
 	end
 end

--- a/test/kernel/sync.rb
+++ b/test/kernel/sync.rb
@@ -27,19 +27,39 @@ describe Kernel do
 				expect(task.annotation).to be == 'foobar'
 			end
 		end
-		
+
 		it "can run inside reactor" do
 			Async do |task|
 				result = Sync do |sync_task|
 					expect(Async::Task.current).to be == task
 					expect(sync_task).to be == task
-					
+
 					next value
 				end
-				
+
 				expect(result).to be == value
 			end
 		end
+
+		with "parent task" do
+			it "replaces and restores existing task's annotation" do
+				annotations = []
+
+				Async(annotation: "foo") do |t1|
+					annotations << t1.annotation
+
+					Sync(annotation: "bar") do |t2|
+						expect(t2).to be_equal(t1)
+						annotations << t1.annotation
+					end
+
+					annotations << t1.annotation
+				end.wait
+
+				expect(annotations).to be == %w[foo bar foo]
+			end
+		end
+
 		
 		it "can propagate error without logging them" do
 			expect(Console).not.to receive(:error)

--- a/test/kernel/sync.rb
+++ b/test/kernel/sync.rb
@@ -21,6 +21,12 @@ describe Kernel do
 			
 			expect(result).to be == value
 		end
+
+		it "passes options through to initial task" do
+			Sync(annotation: 'foobar') do |task|
+				expect(task.annotation).to be == 'foobar'
+			end
+		end
 		
 		it "can run inside reactor" do
 			Async do |task|

--- a/test/kernel/sync.rb
+++ b/test/kernel/sync.rb
@@ -22,7 +22,7 @@ describe Kernel do
 			expect(result).to be == value
 		end
 
-		it "passes options through to initial task" do
+		it "passes annotation through to initial task" do
 			Sync(annotation: 'foobar') do |task|
 				expect(task.annotation).to be == 'foobar'
 			end


### PR DESCRIPTION
Just for symmetry with `Kernel#Async`. In a library I changed the specs to always run in a `Sync {...}` block which meant I had to change the main reactor from `Async(annotation: 'x') { ... }` to `Async(annotation: 'x') { ... }.wait` because `Kernel#Sync` didn't take an annotation. This PR allows it to be just `Sync(annotation: 'x') { ... }`.