### PR TITLE
Add support for `Fiber::Scheduler#blocking_operation_wait`.

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -338,6 +338,25 @@ module Async
 			return @selector.process_wait(Fiber.current, pid, flags)
 		end
 		
+		# Wait for the given work to be executed.
+		#
+		# @public Since *Async v2.19* and *Ruby v3.4*.
+		# @asynchronous May be non-blocking.
+		#
+		# @parameter work [Proc] The work to execute on a background thread.
+		# @returns [Object] The result of the work.
+		def blocking_operation_wait(work)
+			thread = Thread.new(&work)
+			
+			result = thread.join
+			
+			thread = nil
+			
+			return result
+		ensure
+			thread&.kill
+		end
+		
 		# Run one iteration of the event loop.
 		#
 		# When terminating the event loop, we already know we are finished. So we don't need to check the task tree. This is a logical requirement because `run_once` ignores transient tasks. For example, a single top level transient task is not enough to keep the reactor running, but during termination we must still process it in order to terminate child tasks.

--- a/test/io/buffer.rb
+++ b/test/io/buffer.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+describe IO::Buffer do
+	it "can copy a large buffer (releasing the GVL)" do
+		source = IO::Buffer.new(1024 * 1024 * 10)
+		destination = IO::Buffer.new(source.size)
+		
+		source.copy(destination)
+	end
+end


### PR DESCRIPTION
This is a very basic implementation of the `Fiber::Scheduler#blocking_operation_wait` hook.

See <https://bugs.ruby-lang.org/issues/20876> for more context.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.
 
## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
