### PR TITLE
Worker pool for efficient handling of `blocking_operation_wait`.

### DIFF
--- a/lib/async/worker_pool.rb
+++ b/lib/async/worker_pool.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require "etc"
+
+module Async
+	# A simple work pool that offloads work to a background thread.
+	#
+	# @private
+	class WorkerPool
+		class Promise
+			def initialize(work)
+				@work = work
+				@state = :pending
+				@value = nil
+				@guard = ::Mutex.new
+				@condition = ::ConditionVariable.new
+				@thread = nil
+			end
+			
+			def call
+				work = nil
+				
+				@guard.synchronize do
+					@thread = ::Thread.current
+					
+					return unless work = @work
+				end
+				
+				resolve(work.call)
+			rescue Exception => error
+				reject(error)
+			end
+			
+			private def resolve(value)
+				@guard.synchronize do
+					@work = nil
+					@thread = nil
+					@value = value
+					@state = :resolved
+					@condition.broadcast
+				end
+			end
+			
+			private def reject(error)
+				@guard.synchronize do
+					@work = nil
+					@thread = nil
+					@value = error
+					@state = :failed
+					@condition.broadcast
+				end
+			end
+			
+			def cancel
+				return unless @work
+				
+				@guard.synchronize do
+					@work = nil
+					@state = :cancelled
+					@thread&.raise(Interrupt)
+				end
+			end
+			
+			def wait
+				@guard.synchronize do
+					while @state == :pending
+						@condition.wait(@guard)
+					end
+					
+					if @state == :failed
+						raise @value
+					else
+						return @value
+					end
+				end
+			end
+		end
+		
+		# A handle to the work being done.
+		class Worker
+			def initialize
+				@work = ::Thread::Queue.new
+				@thread = ::Thread.new(&method(:run))
+			end
+			
+			def run
+				while work = @work.pop
+					work.call
+				end
+			end
+			
+			def close
+				if thread = @thread
+					@thread = nil
+					thread.kill
+				end
+			end
+			
+			# Call the work and notify the scheduler when it is done.
+			def call(work)
+				promise = Promise.new(work)
+				
+				@work.push(promise)
+				
+				begin
+					return promise.wait
+				ensure
+					promise.cancel
+				end
+			end
+		end
+		
+		# Create a new work pool.
+		#
+		# @parameter size [Integer] The number of threads to use.
+		def initialize(size: Etc.nprocessors)
+			@ready = ::Thread::Queue.new
+			
+			size.times do
+				@ready.push(Worker.new)
+			end
+		end
+		
+		# Close the work pool. Kills all outstanding work.
+		def close
+			if ready = @ready
+				@ready = nil
+				ready.close
+				
+				while worker = ready.pop
+					worker.close
+				end
+			end
+		end
+		
+		# Offload work to a thread.
+		#
+		# @parameter work [Proc] The work to be done.
+		def call(work)
+			if ready = @ready
+				worker = ready.pop
+				
+				begin
+					worker.call(work)
+				ensure
+					ready.push(worker)
+				end
+			else
+				raise RuntimeError, "No worker available!"
+			end
+		end
+	end
+end

--- a/test/async/worker_pool.rb
+++ b/test/async/worker_pool.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2022-2024, by Samuel Williams.
+# Copyright, 2024, by Patrik Wenger.
+
+require "async/worker_pool"
+require "sus/fixtures/async"
+
+describe Async::WorkerPool do
+	let(:worker_pool) {subject.new(size: 1)}
+	
+	it "offloads work to a thread" do
+		result = worker_pool.call(proc do
+			Thread.current
+		end)
+		
+		expect(result).not.to be == Thread.current
+	end
+	
+	it "gracefully handles errors" do
+		expect do
+			worker_pool.call(proc do
+				raise ArgumentError, "Oops!"
+			end)
+		end.to raise_exception(ArgumentError, message: be == "Oops!")
+	end
+	
+	it "can cancel work" do
+		sleeping = ::Thread::Queue.new
+		
+		thread = Thread.new do
+			Thread.current.report_on_exception = false
+			
+			worker_pool.call(proc do
+				sleeping.push(true)
+				sleep(1)
+			end)
+		end
+		
+		# Wait for the worker to start:
+		sleeping.pop
+		
+		thread.raise(Interrupt)
+		
+		expect do
+			thread.join
+		end.to raise_exception(Interrupt)
+	end
+	
+	with "#close" do
+		it "can be closed" do
+			worker_pool.close
+			
+			expect do
+				worker_pool.call(proc{})
+			end.to raise_exception(RuntimeError)
+		end
+	end
+end


### PR DESCRIPTION
See <https://github.com/socketry/async/pull/352> for context.

The cost of creating threads and the usage of `nogvl` creates inefficiencies.

`rb_nogvl` should really only be used when the amount of work to be done is greater than some scheduling quantum. In practice, that's hard to achieve, so we also want to minimise the overhead of `blocking_operation_wait` (later abbreviated BOW).

I've been using `async-cable` as a benchmark as it has a good mixture of IO and nogvl (inflate/deflate) operations. Those operations are typically extremely small, so the overhead is revealed greatly. Another benchmark is the recently introduced `IO::Buffer#copy` using nogvl on large buffers. It is the opposite - highly CPU bound (memory bound actually) work with little IO.

Semantics remain unchanged.

## `Async::Cable` Benchmarks

This benchmark is mostly network bound and there are a lot of small calls to inflate/deflate which uses `rb_nogvl`:

| Configuration | Connection Time | Message Time |
|---------------|----------------:|-------------:|
| No BOW        |          0.67ms |      0.024ms |
| Thread BOW    |           2.2ms |       0.96ms |
| Work Pool BOW |          0.83ms |      0.045ms |

Overall, we can see a net loss in performance by offloading `rb_nogvl` with a pure Ruby implementation. I believe we can attribute this to the offloading thread having to re-acquire the GVL which creates unnecessary contention. This is fixable but requires a native code path (probably in the `IO::Event` scheduler implementation.

## `IO::Buffer` Benchmarks

This benchmark is more memory bound and there is essentially zero blocking IO:

| Configuration |   Task Count | Buffer Size | Duration | Throughput |
|---------------|-------------:|------------:|---------:|-----------:|
| No BOW        |            1 |      100MiB |   6.46ms |     15GB/s | 
| No BOW        |            8 |      100MiB |  28.93ms |     27GB/s |
| No BOW        |           16 |      100MiB |  56.81ms |     28GB/s |
| Thread BOW    |            1 |      100MiB |   6.99ms |     14GB/s |
| Thread BOW    |            8 |      100MiB |  24.52ms |     32GB/s |
| Thread BOW    |           16 |      100MiB |  44.33ms |     36GB/s |
| Work Pool BOW |            1 |      100MiB |   7.12ms |     14GB/s |
| Work Pool BOW |            8 |      100MiB |  20.41ms |     39GB/s |
| Work Pool BOW |           16 |      100MiB |  43.53ms |     36GB/s |

Overall, the thread and work pool are similar. I believe we see GVL contention even on the background threads as I'd expect the numbers to be a little more linear, although it's also true the memory bandwidth isn't unlimited.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
