### PR TITLE
Redefine aliases for LimitedQueue

### DIFF
--- a/lib/async/queue.rb
+++ b/lib/async/queue.rb
@@ -125,13 +125,16 @@ module Async
 		# If the queue is full, this method will block until there is space available.
 		#
 		# @parameter item [Object] The item to add to the queue.
-		def <<(item)
+		def push(item)
 			while limited?
 				@full.wait
 			end
 			
 			super
 		end
+
+		# Compatibility with {::Queue#push}.
+		alias << push
 		
 		# Add multiple items to the queue.
 		#
@@ -163,5 +166,8 @@ module Async
 			
 			return item
 		end
+		
+		# Compatibility with {::Queue#pop}.
+		alias pop dequeue
 	end
 end

--- a/test/async/queue.rb
+++ b/test/async/queue.rb
@@ -244,13 +244,21 @@ describe Async::LimitedQueue do
 					queue << :item2
 				end
 				
-				reactor.async do |task|
-					task.sleep 0.01
-					expect(queue.items).to contain_exactly :item1
-					queue.dequeue
-					expect(queue.items).to contain_exactly :item2
+				expect(queue.dequeue).to be == :item1
+				expect(queue.dequeue).to be == :item2
+			end
+
+			with "#pop" do
+				it "waits until a queue is dequeued" do
+					reactor.async do
+						queue << :item2
+					end
+					
+					expect(queue.pop).to be == :item1
+					expect(queue.pop).to be == :item2
 				end
 			end
 		end
 	end
 end
+


### PR DESCRIPTION
👋🏼 I stumbled into this bugfix by only partially reading the documentation 😅 

I was playing with `Async::LimitedQueue`, but called `#pop` on it (which is technically _not_ documented), and it completely hung. Reason being that the `@full` notification doesn't fire on `#pop` because it's referring to the implementation on `Async::Queue` rather than using `Async::LimitedQueue#dequeue`, which correctly signals `@full`.

As a fix, I redefined the aliases in `Async::LimitedQueue` so they pick up the redefinitions. Without the changes, the updated tests will completely hang in the `#pop` case. 

I also noticed the original test for this wasn't actually working because `#contain_exactly` wasn't defined, and so the async block containing the assertions was being completely ignored. I couldn't get the structure of what was there prior to work (even with switching to `#have_value`), so I asserted based on the dequeued values instead. No strong opinion on this :)

## Types of Changes

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
