### PR TITLE
Fix handling of `IO#close` interruption across threads/fibers.

### DIFF
--- a/test/io.rb
+++ b/test/io.rb
@@ -116,10 +116,14 @@ describe IO do
 				expect do
 					r.read(5)
 				end.to raise_exception(IOError, message: be =~ /stream closed/)
+			ensure
+				puts "Exiting read task"
 			end
 			
 			close_task = Async do
 				r.close
+			ensure
+				puts "Exiting close task"
 			end
 			
 			close_task.wait
@@ -188,7 +192,7 @@ describe IO do
 			
 			expect do
 				read_thread.join
-			end.to raise_exception(IOError, message: be =~ /stream closed/)
+			end.to raise_exception(IOError, message: be =~ /closed/)
 		end
 		
 		it "can interrupt reading fiber in a new thread when closing from a fiber" do
@@ -201,7 +205,7 @@ describe IO do
 				read_task = Async do
 					expect do
 						r.read(5)
-					end.to raise_exception(IOError, message: be =~ /stream closed/)
+					end.to raise_exception(IOError, message: be =~ /closed/)
 				end
 				read_task.wait
 			end

--- a/test/io.rb
+++ b/test/io.rb
@@ -90,4 +90,131 @@ describe IO do
 			out.close
 		end
 	end
+	
+	with "#close" do
+		it "can interrupt reading fiber when closing" do
+			skip_unless_minimum_ruby_version("3.5")
+			
+			r, w = IO.pipe
+			
+			read_task = Async do
+				expect do
+					r.read(5)
+				end.to raise_exception(IOError, message: be =~ /stream closed/)
+			end
+			
+			r.close
+			read_task.wait
+		end
+		
+		it "can interrupt reading fiber when closing from another fiber" do
+			skip_unless_minimum_ruby_version("3.5")
+			
+			r, w = IO.pipe
+			
+			read_task = Async do
+				expect do
+					r.read(5)
+				end.to raise_exception(IOError, message: be =~ /stream closed/)
+			end
+			
+			close_task = Async do
+				r.close
+			end
+			
+			close_task.wait
+			read_task.wait
+		end
+		
+		it "can interrupt reading fiber when closing from a new thread" do
+			skip_unless_minimum_ruby_version("3.5")
+			
+			r, w = IO.pipe
+			
+			read_task = Async do
+				expect do
+					r.read(5)
+				end.to raise_exception(IOError, message: be =~ /stream closed/)
+			end
+			
+			close_thread = Thread.new do
+				r.close
+			end
+			
+			close_thread.value
+			read_task.wait
+		end
+		
+		it "can interrupt reading fiber when closing from a fiber in a new thread" do
+			skip_unless_minimum_ruby_version("3.5")
+			
+			r, w = IO.pipe
+			
+			read_task = Async do
+				expect do
+					r.read(5)
+				end.to raise_exception(IOError, message: be =~ /stream closed/)
+			end
+			
+			close_thread = Thread.new do
+				close_task = Async do
+					r.close
+				end
+				close_task.wait
+			end
+			
+			close_thread.value
+			read_task.wait
+		end
+		
+		it "can interrupt reading thread when closing from a fiber" do
+			skip_unless_minimum_ruby_version("3.5")
+			
+			r, w = IO.pipe
+			
+			read_thread = Thread.new do
+				Thread.current.report_on_exception = false
+				r.read(5)
+			end
+			
+			# Wait until read_thread blocks on I/O
+			Thread.pass until read_thread.status == "sleep"
+			
+			close_task = Async do
+				r.close
+			end
+			
+			close_task.wait
+			
+			expect do
+				read_thread.join
+			end.to raise_exception(IOError, message: be =~ /stream closed/)
+		end
+		
+		it "can interrupt reading fiber in a new thread when closing from a fiber" do
+			skip_unless_minimum_ruby_version("3.5")
+			
+			r, w = IO.pipe
+			
+			read_thread = Thread.new do
+				Thread.current.report_on_exception = false
+				read_task = Async do
+					expect do
+						r.read(5)
+					end.to raise_exception(IOError, message: be =~ /stream closed/)
+				end
+				read_task.wait
+			end
+			
+			# Wait until read_thread blocks on I/O
+			Thread.pass until read_thread.status == "sleep"
+			
+			close_task = Async do
+				r.close
+			end
+			close_task.wait
+			
+			read_thread.value
+		end
+	end
 end


### PR DESCRIPTION
See <https://github.com/socketry/async/issues/368> for more context.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
