### PR TITLE
Add support for `IO::Event::Profiler`.

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.29"
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "io-event", "~> 1.7"
+	spec.add_dependency "io-event", "~> 1.9"
 	spec.add_dependency "traces", "~> 0.15"
 	spec.add_dependency "metrics", "~> 0.12"
 end

--- a/gems.rb
+++ b/gems.rb
@@ -10,6 +10,7 @@ source "https://rubygems.org"
 gemspec
 
 # gem "io-event", git: "https://github.com/socketry/io-event.git"
+gem "fiber-profiler"
 
 group :maintenance, optional: true do
 	gem "bake-gem"

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -42,10 +42,12 @@ module Async
 		# @public Since *Async v1*.
 		# @parameter parent [Node | Nil] The parent node to use for task hierarchy.
 		# @parameter selector [IO::Event::Selector] The selector to use for event handling.
-		def initialize(parent = nil, selector: nil, worker_pool: DEFAULT_WORKER_POOL)
+		def initialize(parent = nil, selector: nil, profiler: IO::Event::Profiler.default, worker_pool: DEFAULT_WORKER_POOL)
 			super(parent)
 			
 			@selector = selector || ::IO::Event::Selector.new(Fiber.current)
+			@profiler = profiler
+			
 			@interrupted = false
 			
 			@blocked = 0
@@ -492,13 +494,19 @@ module Async
 		def run(...)
 			Kernel.raise ClosedError if @selector.nil?
 			
-			initial_task = self.async(...) if block_given?
-			
-			self.run_loop do
-				run_once
+			begin
+				@profiler&.start
+				
+				initial_task = self.async(...) if block_given?
+				
+				self.run_loop do
+					run_once
+				end
+				
+				return initial_task
+			ensure
+				@profiler&.stop
 			end
-			
-			return initial_task
 		end
 		
 		# Start an asynchronous task within the specified reactor. The task will be executed until the first blocking call, at which point it will yield and and this method will return.

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -15,6 +15,14 @@ require "console"
 require "resolv"
 
 module Async
+	begin
+		require "fiber/profiler"
+		Profiler = Fiber::Profiler
+	rescue LoadError
+		# Fiber::Profiler is not available.
+		Profiler = nil
+	end
+	
 	# Handles scheduling of fibers. Implements the fiber scheduler interface.
 	class Scheduler < Node
 		DEFAULT_WORKER_POOL = ENV.fetch("ASYNC_SCHEDULER_DEFAULT_WORKER_POOL", nil).then do |value|
@@ -42,7 +50,7 @@ module Async
 		# @public Since *Async v1*.
 		# @parameter parent [Node | Nil] The parent node to use for task hierarchy.
 		# @parameter selector [IO::Event::Selector] The selector to use for event handling.
-		def initialize(parent = nil, selector: nil, profiler: IO::Event::Profiler.default, worker_pool: DEFAULT_WORKER_POOL)
+		def initialize(parent = nil, selector: nil, profiler: Profiler&.default, worker_pool: DEFAULT_WORKER_POOL)
 			super(parent)
 			
 			@selector = selector || ::IO::Event::Selector.new(Fiber.current)

--- a/test/io.rb
+++ b/test/io.rb
@@ -45,12 +45,14 @@ describe IO do
 		it "can write with timeout" do
 			skip_unless_constant_defined(:TimeoutError, IO)
 			
+			big = "x" * 1024 * 1024
+			
 			input, output = IO.pipe
 			output.timeout = 0.001
 			
 			expect do
 				while true
-					output.write("Hello")
+					output.write(big)
 				end
 			end.to raise_exception(::IO::TimeoutError)
 		end


### PR DESCRIPTION
It turns out we need to profile more than just scheduling operations to get a full picture of stalls in the event loop. This wraps `Async::Scheduler#run` in `IO::Event::Profiler` which tracks any fiber switch in order to log stalls.

Use `IO_EVENT_PROFILER=true` to enable the default profiler. See <https://socketry.github.io/io-event/releases/index#improved-io::event::profiler-for-detecting-stalls.> for more details.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
