### PR TITLE
Add optional support for the `fiber-profiler` gem.

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -27,8 +27,15 @@ jobs:
             ruby: "3.3"
             selector: EPoll
           - os: ubuntu
-            ruby: "3.3"
+            ruby: "3.4"
+            selector: EPoll
+          - os: ubuntu
+            ruby: "3.4"
             selector: URing
+          - os: ubuntu
+            ruby: "3.4"
+            selector: URing
+            fiber_profile_capture: "true"
           - os: ubuntu
             ruby: "head"
             selector: URing
@@ -36,6 +43,9 @@ jobs:
             ruby: "head"
             selector: URing
             worker_pool: "true"
+    
+    env:
+      FIBER_PROFILER_CAPTURE: ${{matrix.fiber_profile_capture}}
     
     steps:
     - uses: actions/checkout@v4
@@ -51,13 +61,14 @@ jobs:
       env:
         IO_EVENT_SELECTOR: ${{matrix.selector}}
         ASYNC_SCHEDULER_DEFAULT_WORKER_POOL: ${{matrix.worker_pool}}
+        FIBER_PROFILER_CAPTURE: ${{matrix.fiber_profile_capture}}
       run: bundle exec bake test
     
     - uses: actions/upload-artifact@v4
       with:
         include-hidden-files: true
         if-no-files-found: error
-        name: coverage-${{matrix.os}}-${{matrix.ruby}}-${{matrix.selector}}-${{matrix.worker_pool}}
+        name: coverage-${{matrix.os}}-${{matrix.ruby}}-${{matrix.selector}}-${{matrix.worker_pool}}-${{matrix.fiber_profile_capture}}
         path: .covered.db
   
   validate:

--- a/async.gemspec
+++ b/async.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.29"
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "io-event", "~> 1.7"
+	spec.add_dependency "io-event", "~> 1.9"
 	spec.add_dependency "traces", "~> 0.15"
 	spec.add_dependency "metrics", "~> 0.12"
 end

--- a/gems.rb
+++ b/gems.rb
@@ -10,7 +10,11 @@ source "https://rubygems.org"
 gemspec
 
 # gem "io-event", git: "https://github.com/socketry/io-event.git"
-gem "fiber-profiler"
+
+# In order to capture both code paths in coverage, we need to optionally load this gem:
+if ENV["FIBER_PROFILER_CAPTURE"] == "true"
+	gem "fiber-profiler"
+end
 
 group :maintenance, optional: true do
 	gem "bake-gem"

--- a/gems.rb
+++ b/gems.rb
@@ -10,6 +10,7 @@ source "https://rubygems.org"
 gemspec
 
 # gem "io-event", git: "https://github.com/socketry/io-event.git"
+gem "fiber-profiler"
 
 group :maintenance, optional: true do
 	gem "bake-gem"

--- a/test/io.rb
+++ b/test/io.rb
@@ -45,12 +45,14 @@ describe IO do
 		it "can write with timeout" do
 			skip_unless_constant_defined(:TimeoutError, IO)
 			
+			big = "x" * 1024 * 1024
+			
 			input, output = IO.pipe
 			output.timeout = 0.001
 			
 			expect do
 				while true
-					output.write("Hello")
+					output.write(big)
 				end
 			end.to raise_exception(::IO::TimeoutError)
 		end


### PR DESCRIPTION
Introduce optional support for the `fiber-profiler` gem. If it is available, and enabled using the `FIBER_PROFILER_CAPTURE=true` environment variable, it will be automatically added to the `Async::Scheduler`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
