### PR TITLE
fixed a tiny typo in the debugging docs

### DIFF
--- a/guides/debugging/readme.md
+++ b/guides/debugging/readme.md
@@ -23,7 +23,7 @@ Using `Fiber.blocking{}` prevents any context switching until the block is compl
 
 ### Debugging with IRB
 
-You ca use IRB to debug your Async program. In some cases, you will want to stop the world and inspect the state of your program. You can do this by wrapping `binding.irb` inside a `Fiber.blocking{}` block:
+You can use IRB to debug your Async program. In some cases, you will want to stop the world and inspect the state of your program. You can do this by wrapping `binding.irb` inside a `Fiber.blocking{}` block:
 
 ```ruby
 Async do


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

Fixed the typo `You ca use IRB to debug your Async program.` to `You can use IRB to debug your Async program.` in  guides/debugging/readme.md

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
