### PR TITLE
Remove unused variable `error`

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -298,7 +298,7 @@ module Async
 					begin
 						# There is a chance that this will stop the fiber that originally called stop. If that happens, the exception handling in `#stopped` will rescue the exception and re-raise it later.
 						Fiber.scheduler.raise(@fiber, Stop)
-					rescue FiberError => error
+					rescue FiberError
 						# In some cases, this can cause a FiberError (it might be resumed already), so we schedule it to be stopped later:
 						Fiber.scheduler.push(Stop::Later.new(self))
 					end


### PR DESCRIPTION
I use the Async gem to run tests. The following warning is displayed at runtime, which is a bit annoying.

> home/ledsun/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/async-2.23.0/lib/async/task.rb:301: warning: assigned but unused variable - error

<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
