### PR TITLE
Correct comment about when blocking_operation_wait() was released

### DIFF
--- a/lib/async/worker_pool.rb
+++ b/lib/async/worker_pool.rb
@@ -14,7 +14,7 @@ module Async
 		module BlockingOperationWait
 			# Wait for the given work to be executed.
 			#
-			# @public Since *Async v2.19* and *Ruby v3.4*.
+			# @public Since *Async v2.21* and *Ruby v3.4*.
 			# @asynchronous May be non-blocking.
 			#
 			# @parameter work [Proc] The work to execute on a background thread.


### PR DESCRIPTION
The hook is not in the v2.19.0 tag.
https://github.com/socketry/async/commit/c317990a4f44f14d43c27d77d663abfcfab89b62 shows that it was first added with v2.21.0.