### PR TITLE
Add support for `stop(cause:)`.

### DIFF
--- a/lib/async/stop.rb
+++ b/lib/async/stop.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require "fiber"
+require "console"
+
+module Async
+	# Raised when a task is explicitly stopped.
+	class Stop < Exception
+		# Represents the source of the stop operation.
+		class Cause < Exception
+			if RUBY_VERSION >= "3.4"
+				# @returns [Array(Thread::Backtrace::Location)] The backtrace of the caller.
+				def self.backtrace
+					caller_locations(2..-1)
+				end
+			else
+				# @returns [Array(String)] The backtrace of the caller.
+				def self.backtrace
+					caller(2..-1)
+				end
+			end
+			
+			# Create a new cause of the stop operation, with the given message.
+			#
+			# @parameter message [String] The error message.
+			# @returns [Cause] The cause of the stop operation.
+			def self.for(message = "Task was stopped")
+				instance = self.new(message)
+				instance.set_backtrace(self.backtrace)
+				return instance
+			end
+		end
+		
+		if RUBY_VERSION < "3.5"
+			# Create a new stop operation.
+			#
+			# This is a compatibility method for Ruby versions before 3.5 where cause is not propagated correctly when using {Fiber#raise}
+			#
+			# @parameter message [String | Hash] The error message or a hash containing the cause.
+			def initialize(message = "Task was stopped")
+				if message.is_a?(Hash)
+					@cause = message[:cause]
+					message = "Task was stopped"
+				end
+				
+				super(message)
+			end
+			
+			# @returns [Exception] The cause of the stop operation.
+			#
+			# This is a compatibility method for Ruby versions before 3.5 where cause is not propagated correctly when using {Fiber#raise}, we explicitly capture the cause here.
+			def cause
+				super || @cause
+			end
+		end
+		
+		# Used to defer stopping the current task until later.
+		class Later
+			# Create a new stop later operation.
+			#
+			# @parameter task [Task] The task to stop later.
+			# @parameter cause [Exception] The cause of the stop operation.
+			def initialize(task, cause = nil)
+				@task = task
+				@cause = cause
+			end
+			
+			# @returns [Boolean] Whether the task is alive.
+			def alive?
+				true
+			end
+			
+			# Transfer control to the operation - this will stop the task.
+			def transfer
+				@task.stop(false, cause: @cause)
+			end
+		end
+	end
+end

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -553,7 +553,7 @@ describe Async::Task do
 			end.wait
 		end
 		
-		it "can stop a task and provide a cause" do
+		it "can stop a task from within with a cause" do
 			error = nil
 			
 			cause = Async::Stop::Cause.for("boom")
@@ -565,6 +565,30 @@ describe Async::Task do
 					raise
 				end
 			end
+			
+			reactor.run
+			
+			expect(task).to be(:stopped?)
+			expect(error).to be_a(Async::Stop)
+			expect(error.cause).to be == cause
+		end
+		
+		it "can stop a task from outside with a cause" do
+			skip_unless_minimum_ruby_version("3.5")
+			
+			error = nil
+			
+			cause = RuntimeError.new("boom")
+			
+			task = reactor.async do |task|
+				begin
+					task.yield
+				rescue Async::Stop => error
+					raise
+				end
+			end
+			
+			task.stop(cause: cause)
 			
 			reactor.run
 			

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -574,8 +574,6 @@ describe Async::Task do
 		end
 		
 		it "can stop a task from outside with a cause" do
-			skip_unless_minimum_ruby_version("3.5")
-			
 			error = nil
 			
 			cause = RuntimeError.new("boom")

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -552,6 +552,26 @@ describe Async::Task do
 				expect(transient).to be(:running?)
 			end.wait
 		end
+		
+		it "can stop a task and provide a cause" do
+			error = nil
+			
+			cause = Async::Stop::Cause.for("boom")
+			
+			task = reactor.async do |task|
+				begin
+					task.stop(cause: cause)
+				rescue Async::Stop => error
+					raise
+				end
+			end
+			
+			reactor.run
+			
+			expect(task).to be(:stopped?)
+			expect(error).to be_a(Async::Stop)
+			expect(error.cause).to be == cause
+		end
 	end
 	
 	with "#sleep" do
@@ -923,7 +943,7 @@ describe Async::Task do
 			
 			reactor.run_once(0)
 			
-			expect(child_task.stop_deferred?).to be == nil
+			expect(child_task.stop_deferred?).to be == false
 		end
 	end
 	


### PR DESCRIPTION
Add `cause:` to `Async::Task#stop(cause:)` so that extra information about the **reason** for stopping can be provided. It must be an exception suitable for `raise Async::Stop, cause: cause`.

Fixes <https://github.com/socketry/async/issues/387>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
