### PR TITLE
Add `io_select` hook.

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -414,6 +414,16 @@ module Async
 			return @selector.process_wait(Fiber.current, pid, flags)
 		end
 		
+		# Wait for the specified IOs to become ready for the specified events.
+		#
+		# @public Since *Async v2.25*.
+		# @asynchronous May be non-blocking.
+		def io_select(...)
+			Thread.new do
+				::IO.select(...)
+			end.value
+		end
+		
 		# Run one iteration of the event loop.
 		#
 		# When terminating the event loop, we already know we are finished. So we don't need to check the task tree. This is a logical requirement because `run_once` ignores transient tasks. For example, a single top level transient task is not enough to keep the reactor running, but during termination we must still process it in order to terminate child tasks.

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added support for `io_select` hook in the fiber scheduler, allowing non-blocking `IO.select` operations. This enables better integration with code that uses `IO.select` for multiplexing IO operations.
+
 ### Use `IO::Event::WorkerPool` for Blocking Operations
 
 The `Async::WorkerPool` implementation has been removed in favor of using `IO::Event::WorkerPool` directly. This change simplifies the codebase by delegating worker pool functionality to the `io-event` gem, which provides a more efficient and well-tested implementation.


### PR DESCRIPTION
This should improve the integration with the HTTPX scheduler implementation that uses `IO.select`.

See <https://github.com/socketry/falcon/issues/288> for more context.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
