### PR TITLE
Revert breaking change of minimum required ruby version introduced due to the latest io-event gem

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.29"
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "io-event", "~> 1.12"
+	spec.add_dependency "io-event", "~> 1.11"
 	spec.add_dependency "metrics", "~> 0.12"
 	spec.add_dependency "traces", "~> 0.15"
 end


### PR DESCRIPTION


<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

I'm using `async` 2.25.0 in a Rails app running on Ruby 3.2.2. I tried to upgrade to async 2.26.0, but the `io-async` gem's latest version ([commit](https://github.com/socketry/io-event/commit/e5e756b15e135a384fbd45f030570c3f4a4f17bf)) has introduced a breaking change on the minimum required Ruby version (now requires Ruby >=3.2.6 instead of >=3.2).

This commit reverts the minimum required version of `io-async` gem in `async` to `~> 1.11` to maintain `async` gem's compatibility with Ruby >=3.2

## Type of Change

- Revert Breaking change.

## Contribution

- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
