### PR TITLE
Restrict async to MRI Ruby only

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,12 +29,6 @@ jobs:
         
         include:
           - os: ubuntu
-            ruby: truffleruby
-            experimental: true
-          - os: ubuntu
-            ruby: jruby
-            experimental: true
-          - os: ubuntu
             ruby: head
             experimental: true
     

--- a/async.gemspec
+++ b/async.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |spec|
 	spec.files = Dir.glob(["{lib}/**/*", "*.md"], File::FNM_DOTMATCH, base: __dir__)
 	
 	spec.required_ruby_version = ">= 3.2"
+	spec.required_ruby_engine = "ruby"
 	
 	spec.add_dependency "console", "~> 1.29"
 	spec.add_dependency "fiber-annotation"

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -347,7 +347,7 @@ module Async
 				timer&.cancel!
 			end
 			
-			if RUBY_ENGINE != "ruby" || RUBY_VERSION >= "3.3.1"
+			if RUBY_VERSION >= "3.3.1"
 				# Write the specified buffer to the IO.
 				#
 				# @public Since *Async v2* and *Ruby v3.3.1* with `IO::Buffer` support.


### PR DESCRIPTION
## Summary

Remove JRuby and TruffleRuby from CI configuration, add required_ruby_engine restriction to gemspec, and simplify Ruby engine checks in scheduler.rb.

Async depends on gems that require C compilation (io-event), and Java engines already have their own async counterparts.