### PR TITLE
Add `Async::PriorityQueue` for Consumer-Priority Resource Allocation.

### DIFF
--- a/fixtures/async/a_priority_queue.rb
+++ b/fixtures/async/a_priority_queue.rb
@@ -1,0 +1,195 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+# Copyright, 2025, by Shopify Inc.
+
+require "async"
+require "async/priority_queue"
+require "sus/fixtures/async"
+
+require "async/chainable_async"
+
+module Async
+	APriorityQueue = Sus::Shared("a priority queue") do
+		let(:queue) {subject.new}
+		
+		# Include all basic queue behaviors
+		it_behaves_like Async::AQueue
+		
+		with "priority ordering" do
+			it "serves consumers in priority order" do
+				results = []
+				
+				# Create consumers with different priorities
+				low = reactor.async do
+					results << queue.dequeue(priority: 1)
+				end
+				
+				high = reactor.async do
+					results << queue.dequeue(priority: 10)
+				end
+				
+				reactor.yield
+				
+				# Add items
+				queue.push(:first_item)
+				queue.push(:second_item)
+				
+				[low, high].each(&:wait)
+				
+				# High priority should get first item
+				expect(results).to be == [:first_item, :second_item]
+				# Verify high priority got the first item by checking task completion order
+			end
+			
+			it "maintains FIFO within same priority" do
+				results = []
+				
+				first = reactor.async do
+					results << [:first, queue.dequeue(priority: 5)]
+				end
+				
+				second = reactor.async do
+					results << [:second, queue.dequeue(priority: 5)]
+				end
+				
+				reactor.yield
+				
+				queue.push(:item1)
+				queue.push(:item2)
+				
+				[first, second].each(&:wait)
+				
+				expect(results).to be == [
+					[:first, :item1],
+					[:second, :item2]
+				]
+			end
+			
+			it "allows priority-based queue jumping" do
+				results = []
+				
+				# Start low priority consumer first
+				low = reactor.async do
+					results << [:low, queue.dequeue(priority: 1)]
+				end
+				
+				reactor.yield
+				
+				# Start high priority consumer after low is waiting
+				high = reactor.async do
+					results << [:high, queue.dequeue(priority: 10)]
+				end
+				
+				reactor.yield
+				
+				# High priority should get the first item despite arriving later
+				queue.push(:item1)
+				high.wait
+				
+				queue.push(:item2)
+				low.wait
+				
+				expect(results).to be == [
+					[:high, :item1],
+					[:low, :item2]
+				]
+			end
+		end
+		
+		with "priority methods" do
+			it "supports priority parameter in dequeue" do
+				queue.push(:item)
+				expect(queue.dequeue(priority: 5)).to be == :item
+			end
+			
+			it "supports priority parameter in pop" do
+				queue.push(:item)
+				expect(queue.pop(priority: 5)).to be == :item
+			end
+			
+			it "supports priority parameter in wait" do
+				reactor.async {queue.push(:item)}
+				expect(queue.wait(priority: 5)).to be == :item
+			end
+			
+			it "supports priority parameter in each" do
+				items = [:item1, :item2]
+				reactor.async do
+					items.each {|item| queue.push(item)}
+					queue.push(nil)
+				end
+				
+				results = []
+				queue.each(priority: 5) do |item|
+					results << item
+				end
+				
+				expect(results).to be == items
+			end
+			
+			it "supports priority parameter in async" do
+				reactor.async do
+					queue.push(:item)
+					queue.push(nil)
+				end
+				
+				results = []
+				queue.async(priority: 5) do |task, item|
+					results << item
+				end
+				
+				expect(results).to be == [:item]
+			end
+		end
+		
+		with "#waiting" do
+			it "tracks number of waiting consumers" do
+				expect(queue.waiting).to be == 0
+				
+				task1 = reactor.async {queue.dequeue}
+				reactor.yield
+				expect(queue.waiting).to be == 1
+				
+				task2 = reactor.async {queue.dequeue}
+				reactor.yield
+				expect(queue.waiting).to be == 2
+				
+				queue.push(:item)
+				task1.wait
+				expect(queue.waiting).to be == 1
+				
+				queue.push(:item)
+				task2.wait
+				expect(queue.waiting).to be == 0
+			end
+		end
+		
+		with "edge cases" do
+			it "handles immediate dequeue when items available" do
+				queue.push(:item)
+				expect(queue.dequeue(priority: 1)).to be == :item
+				expect(queue.dequeue(priority: 10)).to be_nil if queue.empty?
+			end
+			
+			it "respects priority when items available but waiters exist" do
+				queue.push(:available)
+				
+				# Start low priority waiter
+				low_task = reactor.async do
+					queue.dequeue(priority: 1)
+				end
+				reactor.yield
+				
+				# High priority should get available item
+				result = queue.dequeue(priority: 10)
+				expect(result).to be == :available
+				
+				# Clean up
+				queue.push(:cleanup)
+				low_task.wait
+			end
+		end
+	end
+end

--- a/lib/async/priority_queue.rb
+++ b/lib/async/priority_queue.rb
@@ -54,6 +54,7 @@ module Async
 			@parent = parent
 			@waiting = IO::Event::PriorityHeap.new
 			@sequence = 0
+			
 			@mutex = Mutex.new
 		end
 		
@@ -158,16 +159,10 @@ module Async
 					return nil
 				end
 				
-				# Fast path: if items available and no waiters, return immediately:
-				if !@items.empty? && @waiting.size == 0
-					return @items.shift
-				end
-				
-				# If items available but there are waiters, check if we have higher priority:
-				if !@items.empty? && @waiting.size > 0
-					# Peek at highest priority waiter:
-					if @waiting.peek && priority > @waiting.peek.priority
-						# We have higher priority, take the item immediately:
+				# Fast path: if items available and either no waiters or we have higher priority:
+				unless @items.empty?
+					head = @waiting.peek
+					if head.nil? or priority > head.priority
 						return @items.shift
 					end
 				end

--- a/lib/async/priority_queue.rb
+++ b/lib/async/priority_queue.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+# Copyright, 2025, by Shopify Inc.
+
+require "io/event/priority_heap"
+require "thread"
+
+module Async
+	# A queue which allows items to be processed in priority order of consumers.
+	#
+	# Unlike a traditional priority queue where items have priorities, this queue 
+	# assigns priorities to consumers (fibers waiting to dequeue). Higher priority
+	# consumers are served first when items become available.
+	#
+	# @public Since *Async v2*.
+	class PriorityQueue
+		# An error raised when trying to enqueue items to a closed queue.
+		class ClosedError < RuntimeError
+		end
+		
+		# A waiter represents a fiber waiting to dequeue with a given priority.
+		Waiter = Struct.new(:fiber, :priority, :sequence, :condition, :value) do
+			include Comparable
+			
+			def <=>(other)
+				# Higher priority comes first, then FIFO for equal priorities:
+				if priority == other.priority
+					# Use sequence for FIFO behavior (lower sequence = earlier):
+					sequence <=> other.sequence
+				else
+					other.priority <=> priority  # Reverse for max-heap behavior
+				end
+			end
+			
+			def signal(value)
+				self.value = value
+				condition.signal
+			end
+			
+			def wait_for_value(mutex)
+				condition.wait(mutex)
+			end
+		end
+		
+		# Create a new priority queue.
+		#
+		# @parameter parent [Interface(:async) | Nil] The parent task to use for async operations.
+		def initialize(parent: nil)
+			@items = []
+			@closed = false
+			@parent = parent
+			@waiting = IO::Event::PriorityHeap.new
+			@sequence = 0
+			@mutex = Mutex.new
+		end
+		
+		# Close the queue, causing all waiting tasks to return `nil`. 
+		# Any subsequent calls to {enqueue} will raise an exception.
+		def close
+			@mutex.synchronize do
+				@closed = true
+				
+				# Signal all waiting fibers with nil:
+				while waiter = @waiting.pop
+					waiter.signal(nil)
+				end
+			end
+		end
+		
+		# @attribute [Array] The items in the queue.
+		attr :items
+		
+		# @returns [Integer] The number of items in the queue.
+		def size
+			@items.size
+		end
+		
+		# @returns [Boolean] Whether the queue is empty.
+		def empty?
+			@items.empty?
+		end
+		
+		# @returns [Integer] The number of fibers waiting to dequeue.
+		def waiting
+			@mutex.synchronize do
+				@waiting.size
+			end
+		end
+		
+		# Add an item to the queue.
+		#
+		# @parameter item [Object] The item to add to the queue.
+		def push(item)
+			@mutex.synchronize do
+				if @closed
+					raise ClosedError, "Cannot push items to a closed queue."
+				end
+				
+				@items << item
+				
+				# Wake up the highest priority waiter if any:
+				if waiter = @waiting.pop
+					value = @items.shift
+					waiter.signal(value)
+				end
+			end
+		end
+		
+		# Compatibility with {::Queue#push}.
+		def <<(item)
+			self.push(item)
+		end
+		
+		# Add multiple items to the queue.
+		#
+		# @parameter items [Array] The items to add to the queue.
+		def enqueue(*items)
+			@mutex.synchronize do
+				if @closed
+					raise ClosedError, "Cannot enqueue items to a closed queue."
+				end
+				
+				@items.concat(items)
+				
+				# Wake up waiting fibers in priority order:
+				while !@items.empty? && (waiter = @waiting.pop)
+					value = @items.shift
+					waiter.signal(value)
+				end
+			end
+		end
+		
+		# Remove and return the next item from the queue.
+		#
+		# If the queue is empty, this method will block until an item is available.
+		# Fibers are served in priority order, with higher priority fibers receiving
+		# items first.
+		#
+		# @parameter priority [Numeric] The priority of this consumer (higher = served first).
+		# @returns [Object] The next item in the queue.
+		def dequeue(priority: 0)
+			@mutex.synchronize do
+				# If queue is closed and empty, return nil immediately:
+				if @closed && @items.empty?
+					return nil
+				end
+				
+				# Fast path: if items available and no waiters, return immediately:
+				if !@items.empty? && @waiting.size == 0
+					return @items.shift
+				end
+				
+				# If items available but there are waiters, check if we have higher priority:
+				if !@items.empty? && @waiting.size > 0
+					# Peek at highest priority waiter:
+					if @waiting.peek && priority > @waiting.peek.priority
+						# We have higher priority, take the item immediately:
+						return @items.shift
+					end
+				end
+				
+				# Need to wait - create our own condition variable and add to waiting queue:
+				sequence = @sequence
+				@sequence += 1
+				condition = ConditionVariable.new
+				waiter = Waiter.new(Fiber.current, priority, sequence, condition, nil)
+				@waiting.push(waiter)
+				
+				# Wait for our specific condition variable to be signaled:
+				# The mutex is released during wait, reacquired after
+				waiter.wait_for_value(@mutex)
+				
+				# Return the value we received (could be nil if queue was closed):
+				return waiter.value
+			end
+		end
+		
+		# Compatibility with {::Queue#pop}.
+		#
+		# @parameter priority [Numeric] The priority of this consumer.
+		def pop(priority: 0)
+			self.dequeue(priority: priority)
+		end
+		
+		# Process each item in the queue.
+		#
+		# @asynchronous Executes the given block concurrently for each item.
+		#
+		# @parameter priority [Numeric] The priority for processing items.
+		# @parameter parent [Interface(:async) | Nil] The parent task to use for async operations.
+		# @parameter options [Hash] The options to pass to the task.
+		# @yields {|task| ...} When the system is idle, the block will be executed in a new task.
+		def async(priority: 0, parent: (@parent or Task.current), **options, &block)
+			while item = self.dequeue(priority: priority)
+				parent.async(item, **options, &block)
+			end
+		end
+		
+		# Enumerate each item in the queue.
+		#
+		# @parameter priority [Numeric] The priority for dequeuing items.
+		def each(priority: 0)
+			while item = self.dequeue(priority: priority)
+				yield item
+			end
+		end
+		
+		# Signal the queue with a value, the same as {#enqueue}.
+		def signal(value = nil)
+			self.enqueue(value)
+		end
+		
+		# Wait for an item to be available, the same as {#dequeue}.
+		#
+		# @parameter priority [Numeric] The priority of this consumer.
+		def wait(priority: 0)
+			self.dequeue(priority: priority)
+		end
+	end
+end

--- a/releases.md
+++ b/releases.md
@@ -7,16 +7,7 @@
 The new `Async::PriorityQueue` provides a thread-safe, fiber-aware queue where consumers can specify priority levels. Higher priority consumers are served first when items become available, with FIFO ordering maintained for equal priorities. This is useful for implementing priority-based task processing systems where critical operations need to be handled before lower priority work.
 
 ```ruby
-Sync do
-	queue = Async::PriorityQueue.new
-	
-	# Start consumers with different priorities:
-	Async {puts queue.dequeue(priority: 1)}   # Low priority
-	Async {puts queue.dequeue(priority: 10)}  # High priority
-	
-	# High priority consumer gets this first:
-	queue.push("item")
-end
+rubo
 ```
 
 ## v2.28.1

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,24 @@
 # Releases
 
+## Unreleased
+
+### Introduce `Async::PriorityQueue`.
+
+The new `Async::PriorityQueue` provides a thread-safe, fiber-aware queue where consumers can specify priority levels. Higher priority consumers are served first when items become available, with FIFO ordering maintained for equal priorities. This is useful for implementing priority-based task processing systems where critical operations need to be handled before lower priority work.
+
+```ruby
+Sync do
+	queue = Async::PriorityQueue.new
+	
+	# Start consumers with different priorities:
+	Async {puts queue.dequeue(priority: 1)}   # Low priority
+	Async {puts queue.dequeue(priority: 10)}  # High priority
+	
+	# High priority consumer gets this first:
+	queue.push("item")
+end
+```
+
 ## v2.28.1
 
   - Fix race condition between `Async::Barrier#stop` and finish signalling.

--- a/test/async/priority_queue.rb
+++ b/test/async/priority_queue.rb
@@ -1,0 +1,445 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+# Copyright, 2025, by Shopify Inc.
+
+require "async/priority_queue"
+
+require "sus/fixtures/async"
+
+describe Async::PriorityQueue do
+	include Sus::Fixtures::Async::ReactorContext
+	
+	let(:queue) {subject.new}
+	
+	with "basic functionality" do
+		it "can push and pop items" do
+			queue.push("item")
+			expect(queue.dequeue).to be == "item"
+		end
+		
+		it "reports size correctly" do
+			expect(queue.size).to be == 0
+			queue.push("item1")
+			expect(queue.size).to be == 1
+			queue.push("item2")
+			expect(queue.size).to be == 2
+			queue.dequeue
+			expect(queue.size).to be == 1
+		end
+		
+		it "reports empty status correctly" do
+			expect(queue.empty?).to be == true
+			queue.push("item")
+			expect(queue.empty?).to be == false
+			queue.dequeue
+			expect(queue.empty?).to be == true
+		end
+	end
+	
+	with "priority behavior" do
+		it "serves higher priority consumers first" do
+			results = []
+			
+			# Start three consumers with different priorities
+			low_priority = reactor.async do
+				results << [:low, queue.dequeue(priority: 1)]
+			end
+			
+			medium_priority = reactor.async do  
+				results << [:medium, queue.dequeue(priority: 5)]
+			end
+			
+			high_priority = reactor.async do
+				results << [:high, queue.dequeue(priority: 10)]
+			end
+			
+			# Let all consumers start waiting
+			reactor.yield
+			
+			# Add items one at a time
+			queue.push(:item1)
+			queue.push(:item2)
+			queue.push(:item3)
+			
+			# Wait for all consumers to finish
+			[low_priority, medium_priority, high_priority].each(&:wait)
+			
+			# Results should be ordered by priority (high to low)
+			expect(results).to be == [
+				[:high, :item1],
+				[:medium, :item2], 
+				[:low, :item3]
+			]
+		end
+		
+		it "maintains FIFO order for equal priorities" do
+			results = []
+			
+			# Start multiple consumers with same priority
+			first = reactor.async do
+				results << [:first, queue.dequeue(priority: 5)]
+			end
+			
+			second = reactor.async do
+				results << [:second, queue.dequeue(priority: 5)]
+			end
+			
+			third = reactor.async do
+				results << [:third, queue.dequeue(priority: 5)]
+			end
+			
+			# Let all consumers start waiting
+			reactor.yield
+			
+			# Add items
+			queue.push(:item1)
+			queue.push(:item2)
+			queue.push(:item3)
+			
+			# Wait for completion
+			[first, second, third].each(&:wait)
+			
+			# Should maintain FIFO order for equal priorities
+			expect(results).to be == [
+				[:first, :item1],
+				[:second, :item2],
+				[:third, :item3]
+			]
+		end
+		
+		it "handles mixed priorities correctly" do
+			results = []
+			
+			# Create consumers in random order with mixed priorities
+			consumer1 = reactor.async do
+				results << [1, queue.dequeue(priority: 3)]
+			end
+			
+			consumer2 = reactor.async do
+				results << [2, queue.dequeue(priority: 1)]  # lowest
+			end
+			
+			consumer3 = reactor.async do
+				results << [3, queue.dequeue(priority: 5)]  # highest
+			end
+			
+			consumer4 = reactor.async do
+				results << [4, queue.dequeue(priority: 3)]  # same as consumer1
+			end
+			
+			reactor.yield
+			
+			# Add items
+			4.times {|i| queue.push("item#{i}")}
+			
+			[consumer1, consumer2, consumer3, consumer4].each(&:wait)
+			
+			# Should be: priority 5, then priority 3 (FIFO), then priority 1
+			expected_order = [3, 1, 4, 2]  # consumer IDs in expected order
+			actual_order = results.map(&:first)
+			
+			expect(actual_order).to be == expected_order
+		end
+		
+		it "allows high priority consumers to jump the queue" do
+			results = []
+			
+			# Start low priority consumer
+			low = reactor.async do
+				results << [:low, queue.dequeue(priority: 1)]
+			end
+			
+			reactor.yield  # Let low priority consumer start waiting
+			
+			# Start high priority consumer after low is already waiting
+			high = reactor.async do
+				results << [:high, queue.dequeue(priority: 10)]
+			end
+			
+			reactor.yield
+			
+			# Add one item - should go to high priority consumer
+			queue.push(:item)
+			
+			high.wait
+			
+			# Add another item for low priority
+			queue.push(:item2)
+			low.wait
+			
+			expect(results).to be == [
+				[:high, :item],
+				[:low, :item2]
+			]
+		end
+		
+		it "handles immediate dequeue when items available" do
+			# Add items first
+			queue.push(:item1)
+			queue.push(:item2)
+			
+			# Dequeue should return immediately regardless of priority
+			expect(queue.dequeue(priority: 1)).to be == :item1
+			expect(queue.dequeue(priority: 10)).to be == :item2
+		end
+		
+		it "respects priority when items available but waiters exist" do
+			results = []
+			
+			# Start a low priority waiter first (no items available yet)
+			low = reactor.async do
+				results << [:low, queue.dequeue(priority: 1)]
+			end
+			
+			# Let the low priority consumer start waiting
+			reactor.yield
+			
+			# Add an item - now we have waiters
+			queue.push(:available_item)
+			
+			# Start another low priority waiter to create more waiters
+			low2 = reactor.async do
+				results << [:low2, queue.dequeue(priority: 1)]
+			end
+			
+			reactor.yield
+			
+			# Now a high priority consumer should jump ahead of remaining waiters
+			high = reactor.async do
+				results << [:high, queue.dequeue(priority: 10)]
+			end
+			
+			reactor.yield
+			
+			# Add more items to satisfy all waiters
+			queue.push(:item2)
+			queue.push(:item3)
+			
+			# Wait for all to complete
+			low.wait
+			low2.wait
+			high.wait
+			
+			# The first low priority consumer got the first item (it was already waiting)
+			# The high priority consumer should have jumped ahead of the second low priority
+			expect(results).to be == [[:low, :available_item], [:high, :item2], [:low2, :item3]]
+		end
+		
+		it "allows high priority consumers to jump queue with items available" do
+			# Add some items first
+			queue.push(:item1)
+			queue.push(:item2)
+			
+			# Start a low priority waiter
+			low_task = reactor.async do
+				queue.dequeue(priority: 1)
+			end
+			
+			reactor.yield
+			
+			# The low priority waiter should have taken item1
+			# High priority consumer gets item2
+			result = queue.dequeue(priority: 10)
+			expect(result).to be == :item2
+			
+			low_task.wait
+		end
+		
+		
+	end
+	
+	with "#waiting" do
+		it "returns the number of waiting fibers" do
+			expect(queue.waiting).to be == 0
+			
+			task1 = reactor.async {queue.dequeue}
+			reactor.yield
+			expect(queue.waiting).to be == 1
+			
+			task2 = reactor.async {queue.dequeue}
+			reactor.yield
+			expect(queue.waiting).to be == 2
+			
+			queue.push(:item)
+			task1.wait
+			expect(queue.waiting).to be == 1
+			
+			queue.push(:item)
+			task2.wait
+			expect(queue.waiting).to be == 0
+		end
+	end
+	
+	with "#async with priority" do
+		it "processes items with specified priority" do
+			results = []
+			
+			# Start async processing with different priorities
+			high_task = reactor.async do
+				queue.async(priority: 10) do |task, item|
+					results << [:high, item]
+				end
+			end
+			
+			low_task = reactor.async do
+				queue.async(priority: 1) do |task, item|
+					results << [:low, item]
+				end
+			end
+			
+			reactor.yield
+			
+			# Add items
+			queue.push(:item1)
+			queue.push(:item2)
+			queue.push(nil)  # Terminal item for high priority
+			queue.push(nil)  # Terminal item for low priority
+			
+			high_task.wait
+			low_task.wait
+			
+			# High priority should get first item
+			expect(results.first).to be == [:high, :item1]
+		end
+	end
+	
+	with "#enqueue" do
+		it "processes multiple items and wakes multiple waiters" do
+			results = []
+			
+			# Start multiple waiters
+			waiter1 = reactor.async do
+				results << [:waiter1, queue.dequeue(priority: 10)]
+			end
+			
+			waiter2 = reactor.async do
+				results << [:waiter2, queue.dequeue(priority: 5)]
+			end
+			
+			waiter3 = reactor.async do
+				results << [:waiter3, queue.dequeue(priority: 1)]
+			end
+			
+			reactor.yield
+			
+			# Add multiple items at once
+			queue.enqueue(:item1, :item2, :item3)
+			
+			waiter1.wait
+			waiter2.wait
+			waiter3.wait
+			
+			# Should be processed in priority order
+			expect(results).to be == [[:waiter1, :item1], [:waiter2, :item2], [:waiter3, :item3]]
+		end
+	end
+	
+	with "#each" do
+		it "iterates through items with priority" do
+			results = []
+			
+			# Start iterator with low priority
+			iterator = reactor.async do
+				queue.each(priority: 1) do |item|
+					results << item
+				end
+			end
+			
+			reactor.yield
+			
+			# Add items and nil to terminate
+			queue.push(:first)
+			queue.push(:second)
+			queue.push(nil)  # Terminates the iterator
+			
+			iterator.wait
+			
+			expect(results).to be == [:first, :second]
+		end
+	end
+	
+	with "#signal and #wait" do
+		it "signal behaves like enqueue" do
+			queue.signal(:test_item)
+			expect(queue.dequeue).to be == :test_item
+		end
+		
+		it "wait behaves like dequeue" do
+			queue.push(:test_item)
+			result = queue.wait(priority: 5)
+			expect(result).to be == :test_item
+		end
+	end
+	
+	with "error handling" do
+		it "handles closed queue correctly" do
+			# Start a waiter
+			task = reactor.async {queue.dequeue(priority: 5)}
+			reactor.yield
+			
+			# Close the queue
+			queue.close
+			
+			# Waiter should receive nil and finish
+			result = task.wait
+			expect(result).to be_nil
+		end
+		
+		it "prevents operations on closed queue" do
+			queue.close
+			
+			expect {queue.push(:item)}.to raise_exception(Async::PriorityQueue::ClosedError)
+			expect {queue.enqueue(:item)}.to raise_exception(Async::PriorityQueue::ClosedError)
+			expect {queue << :item}.to raise_exception(Async::PriorityQueue::ClosedError)
+		end
+		
+		it "returns nil for dequeue on closed empty queue" do
+			queue.close
+			expect(queue.dequeue).to be_nil
+			expect(queue.pop).to be_nil
+		end
+	end
+	
+	with "stress test" do
+		it "handles many concurrent consumers with different priorities" do
+			num_consumers = 100
+			num_items = 100
+			results = []
+			consumers = []
+			
+			# Create consumers with random priorities
+			num_consumers.times do |i|
+				priority = rand(10)
+				consumers << reactor.async do
+					if item = queue.dequeue(priority: priority)
+						results << [i, priority, item]
+					end
+				end
+			end
+			
+			reactor.yield
+			
+			# Add items
+			num_items.times {|i| queue.push("item#{i}")}
+			
+			# Wait for consumers to finish
+			consumers.each(&:wait)
+			
+			# Verify we got the right number of results
+			expect(results.size).to be == num_items
+			
+			# Verify priority ordering - should be roughly sorted by priority (desc)
+			priorities = results.map {|_, priority, _| priority}
+			sorted_priorities = priorities.sort.reverse
+			
+			# Allow some flexibility due to FIFO within same priority
+			# Just check that higher priorities tend to come first
+			high_priority_early = priorities.take(20).sum
+			low_priority_late = priorities.drop(80).sum
+			
+			expect(high_priority_early).to be >= low_priority_late
+		end
+	end
+end

--- a/test/async/priority_queue.rb
+++ b/test/async/priority_queue.rb
@@ -252,8 +252,6 @@ describe Async::PriorityQueue do
 			
 			low_task.wait
 		end
-		
-		
 	end
 	
 	with "#waiting" do


### PR DESCRIPTION
This PR introduces `Async::PriorityQueue`, a unique concurrency primitive that implements the **inverse of traditional task prioritization**. Instead of prioritizing work items, it prioritizes the **consumers** requesting work, enabling sophisticated resource allocation strategies based on who is asking rather than what is being processed.

- **Worker Class Hierarchies**: Critical system processes bypass background job consumers.
- **Load Balancing**: High-priority services get first access to shared resource pools.
- **Capacity Management**: Important consumers reserve access to constrained resources.

### Example

```ruby
Sync do
	queue = Async::PriorityQueue.new
	
	# Start consumers with different priorities:
	Async {puts queue.dequeue(priority: 1)}   # Low priority
	Async {puts queue.dequeue(priority: 10)}  # High priority
	
	# High priority consumer gets this first:
	queue.push("item")
end
```
## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
