### PR TITLE
Deprecate `Async::Variable`.

### DIFF
--- a/lib/async/variable.rb
+++ b/lib/async/variable.rb
@@ -7,11 +7,15 @@ require_relative "condition"
 
 module Async
 	# A synchronization primitive that allows one task to wait for another task to resolve a value.
+	#
+	# @deprecated Use {Async::Promise} instead.
 	class Variable
 		# Create a new variable.
 		#
 		# @parameter condition [Condition] The condition to use for synchronization.
 		def initialize(condition = Condition.new)
+			warn("`Async::Variable` is deprecated, use `Async::Promise` instead.", category: :deprecated, uplevel: 1) if $VERBOSE
+			
 			@condition = condition
 			@value = nil
 		end

--- a/lib/async/waiter.rb
+++ b/lib/async/waiter.rb
@@ -6,6 +6,7 @@
 
 module Async
 	# A composable synchronization primitive, which allows one task to wait for a number of other tasks to complete. It can be used in conjunction with {Semaphore} and/or {Barrier}.
+	#
 	# @deprecated `Async::Waiter` is deprecated, use `Async::Barrier` instead. 
 	class Waiter
 		# Create a waiter instance.

--- a/releases.md
+++ b/releases.md
@@ -4,6 +4,7 @@
 
   - Thread-safe `Async::Condition` and `Async::Notification`, implemented using `Thread::Queue`.
   - Thread-safe `Async::Queue` and `Async::LimitedQueue`, implemented using `Thread::Queue` and `Thread::LimitedQueue` respectively.
+  - `Async::Variable` is deprecated in favor of `Async::Promise`.
 
 ### Introduce `Async::Promise`
 


### PR DESCRIPTION
`Async::Promise` is a better interface and implementation.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
