### PR TITLE
Add support for `Process.fork` within an active scheduler.

### DIFF
--- a/lib/async/fork_handler.rb
+++ b/lib/async/fork_handler.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+module Async
+	# Private module that hooks into Process._fork to handle fork events.
+	#
+	# If `Scheduler#process_fork` hook is adopted in Ruby 4, this code can be removed after Ruby < 4 is no longer supported.
+	module ForkHandler
+		def _fork(&block)
+			result = super
+			
+			if result.zero?
+				# Child process:
+				if Fiber.scheduler.respond_to?(:process_fork)
+					Fiber.scheduler.process_fork
+				end
+			end
+			
+			return result
+		end
+	end
+	
+	private_constant :ForkHandler
+	
+	# Hook into Process._fork to handle fork events automatically:
+	unless (Fiber.const_get(:SCHEDULER_PROCESS_FORK) rescue false)
+		::Process.singleton_class.prepend(ForkHandler)
+	end
+end

--- a/lib/async/node.rb
+++ b/lib/async/node.rb
@@ -214,7 +214,8 @@ module Async
 		end
 		
 		protected def remove_child(child)
-			@children.remove(child)
+			# In the case of a fork, the children list may be nil:
+			@children&.remove(child)
 			child.set_parent(nil)
 		end
 		

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - `Process.fork` is now properly handled by the Async fiber scheduler, ensuring that the scheduler state is correctly reset in the child process after a fork. This prevents issues where the child process inherits the scheduler state from the parent, which could lead to unexpected behavior.
+
 ## v2.34.0
 
 ### `Kernel::Barrier` Convenience Interface

--- a/test/process/fork.rb
+++ b/test/process/fork.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Samuel Williams.
+
+require "sus/fixtures/async"
+require "async"
+
+describe Process do
+	describe ".fork" do
+		it "can fork with block form" do
+			r, w = IO.pipe
+			
+			Async do
+				pid = Process.fork do
+					# Child process:
+					w.write("hello")
+				end
+				
+				# Parent process:
+				w.close
+				expect(r.read).to be == "hello"
+			ensure
+				Process.waitpid(pid) if pid
+			end
+		end
+		
+		it "can fork with non-block form" do
+			r, w = IO.pipe
+			
+			Async do
+				unless pid = Process.fork
+					# Child process:
+					w.write("hello")
+					
+					exit!
+				end
+				
+				# Parent process:
+				w.close
+				expect(r.read).to be == "hello"
+			ensure
+				Process.waitpid(pid) if pid
+			end
+		end
+	end
+end


### PR DESCRIPTION
Previously, `Process.fork` within a scheduler had undefined behaviour. However, after considering it, it looks like we can correctly support it, if we shut down the scheduler in the child process correctly.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
