### PR TITLE
Implement Condition#waiting_count

### DIFF
--- a/fixtures/async/a_condition.rb
+++ b/fixtures/async/a_condition.rb
@@ -58,6 +58,31 @@ module Async
 			expect(order).to be == [0, 1, 2, 3, 4]
 		end
 		
+		it "counts waiting fibers" do
+			expect(condition.waiting_count).to be == 0
+			
+			task1 = reactor.async do
+				condition.wait
+			end
+			task2 = reactor.async do
+				condition.wait
+			end
+			
+			expect(condition.waiting_count).to be == 2
+			
+			task3 = reactor.async do
+				condition.wait
+			end
+			
+			expect(condition.waiting_count).to be == 3
+			
+			condition.signal
+			task1.wait
+			task2.wait
+			task3.wait
+			expect(condition.waiting_count).to be == 0
+		end
+		
 		with "timeout" do
 			let(:ready) {Async::Variable.new(condition)}
 			let(:waiting) {Async::Variable.new(subject.new)}

--- a/lib/async/condition.rb
+++ b/lib/async/condition.rb
@@ -32,7 +32,7 @@ module Async
 			!self.empty?
 		end
 		
-		# @returns [Integer] Number of fibers waiting on this condition
+		# @returns [Integer] Number of fibers waiting on this condition.
 		def waiting_count
 			@ready.num_waiting
 		end

--- a/lib/async/condition.rb
+++ b/lib/async/condition.rb
@@ -32,6 +32,11 @@ module Async
 			!self.empty?
 		end
 		
+		# @returns [Integer] Number of fibers waiting on this condition
+		def waiting_count
+			@ready.num_waiting
+		end
+		
 		# Signal to a given task that it should resume operations.
 		# @parameter value [Object | Nil] The value to return to the waiting fibers.
 		def signal(value = nil)

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Introduce `Async::Condition#waiting_count`. This allows you to see how many tasks are currently waiting on the condition, which can be useful for debugging and monitoring purposes.
+
 ## v2.39.0
 
   - `Async::Barrier#wait` now returns the number of tasks that were waited for, or `nil` if there were no tasks to wait for. This provides better feedback about the operation, and allows you to know how many tasks were involved in the wait.


### PR DESCRIPTION
This adds `Condition#waiting_count` so you can tell how many tasks are waiting for a certain condition, as discussed in #455 

Please let me know if I can improve this PR in any way!

## Types of Changes

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
