### PR TITLE
Make traces and metrics optional dependencies.

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -28,6 +28,4 @@ Gem::Specification.new do |spec|
 	spec.add_dependency "console", "~> 1.29"
 	spec.add_dependency "fiber-annotation"
 	spec.add_dependency "io-event", "~> 1.11"
-	spec.add_dependency "metrics", "~> 0.12"
-	spec.add_dependency "traces", "~> 0.18"
 end

--- a/gems.rb
+++ b/gems.rb
@@ -30,6 +30,8 @@ group :test do
 	gem "sus", "~> 0.31"
 	gem "covered"
 	gem "decode"
+	gem "metrics", "~> 0.12"
+	gem "traces", "~> 0.18"
 	
 	gem "rubocop"
 	gem "rubocop-md"


### PR DESCRIPTION
## Summary
- Remove metrics and traces from the runtime gemspec dependencies.
- Add metrics and traces to the test/development bundle so provider tests and opt-in provider files still work.

## Verification
- ruby -Ilib -e 'spec = Gem::Specification.load("async.gemspec"); abort("unexpected dependency") if spec.dependencies.any? {|dependency| ["metrics", "traces"].include?(dependency.name)}; require "async"; loaded = .grep(%r{/(metrics|traces)/|/(metrics|traces)\.rb\z}); abort("unexpected load: #{loaded.inspect}") unless loaded.empty?; puts "ok"'
- BUNDLE_GEMFILE="gems.rb" bundle exec ruby -Ilib -e 'require "metrics/provider/async/task"; require "traces/provider/async/task"; require "traces/provider/async/barrier"; puts "ok"'