### PR TITLE
Reset blocked operations after fork

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -685,6 +685,7 @@ module Async
 			@children = nil
 			@selector = nil
 			@timers = nil
+			@blocked = 0
 			
 			# Close the scheduler:
 			Fiber.set_scheduler(nil)

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fixed scheduler cleanup after forking while other fibers are blocked.
+
 ## v2.43.0
 
   - Propagate cancellation causes through task trees so child tasks observe the original cancellation cause.

--- a/test/process/fork.rb
+++ b/test/process/fork.rb
@@ -44,5 +44,28 @@ describe Process do
 				Process.waitpid(pid) if pid
 			end
 		end
+		
+		it "can fork while another fiber is blocked" do
+			r, w = IO.pipe
+			queue = Thread::Queue.new
+			
+			Async do |task|
+				blocked_task = task.async do
+					queue.pop
+				end
+				
+				pid = Process.fork do
+					# Child process:
+					w.write("hello")
+				end
+				
+				# Parent process:
+				w.close
+				expect(r.read).to be == "hello"
+			ensure
+				blocked_task&.stop
+				Process.waitpid(pid) if pid
+			end
+		end
 	end
 end


### PR DESCRIPTION
Async scheduler state is copied into a forked child, but the fibers represented by `@blocked` are not. Reset the inherited counter before detaching the child scheduler so `Scheduler#close` does not raise `Closing scheduler with blocked operations!`.

This was exposed by socketry/async-container#76 when moving `Process.fork` from a separate native thread to a clean fiber.

Adds a regression test that forks while another fiber is blocked in `Thread::Queue#pop`.