### PR TITLE
Deliver cross-thread task cancellation on the owning scheduler

### DIFF
--- a/lib/async/task.rb
+++ b/lib/async/task.rb
@@ -332,6 +332,13 @@ module Async
 				cause = Cancel::Cause.for("Cancelling task!")
 			end
 			
+			# If the task belongs to another scheduler, hand cancellation off to that scheduler so all task state and tree mutations happen on the owning thread. This must not depend on @fiber, which is cleared before the task is removed from the tree by #finish!:
+			scheduler = self.reactor
+			if scheduler.respond_to?(:unblock) && !Fiber.scheduler.equal?(scheduler)
+				scheduler.unblock(nil, Cancel::Later.new(self, cause))
+				return
+			end
+			
 			if self.cancelled?
 				# If the task is already cancelled, a `cancel` state transition re-enters the same state which is a no-op. However, we will also attempt to cancel any running children too. This can happen if the children did not cancel correctly the first time around. Doing this should probably be considered a bug, but it's better to be safe than sorry.
 				return cancelled!(cause)

--- a/test/async/task.rb
+++ b/test/async/task.rb
@@ -707,6 +707,114 @@ describe Async::Task do
 			expect(error.cause).to be == cause
 		end
 		
+		it "can cancel a task owned by another thread's scheduler" do
+			ready = Thread::Queue.new
+			cause = RuntimeError.new("boom")
+			cancel_error = nil
+			victim_finished = false
+			
+			owner = Thread.new do
+				Async do |parent|
+					victim = parent.async do
+						begin
+							sleep
+						rescue Async::Cancel => error
+							cancel_error = error
+							raise
+						ensure
+							victim_finished = true
+						end
+					end
+					
+					ready << victim
+					victim.wait
+				end
+			end
+			
+			victim = ready.pop
+			
+			canceller = Thread.new do
+				Async do
+					victim.cancel(cause: cause)
+					victim.wait
+				end
+			end
+			
+			expect(canceller.join(1)).to be == canceller
+			expect(owner.join(1)).to be == owner
+			expect(victim).to be(:cancelled?)
+			expect(victim_finished).to be == true
+			expect(cancel_error&.cause).to be == cause
+		ensure
+			canceller&.kill
+			owner&.kill
+			canceller&.join
+			owner&.join
+		end
+		
+		it "does not finalize a task from another thread while its owner is finishing it" do
+			ready = Thread::Queue.new
+			owner_finishing = Thread::Queue.new
+			owner_error = nil
+			owner_thread = nil
+			
+			owner = Thread.new do
+				owner_thread = Thread.current
+				
+				begin
+					Async do |parent|
+						parent.async do |victim|
+							pause_during_consume = Module.new do
+								define_method(:finished?) do
+									if Thread.current.equal?(owner_thread) && @fiber.nil? && !defined?(@paused_during_consume)
+										@paused_during_consume = true
+										owner_finishing << true
+										Thread.stop
+									end
+									
+									super()
+								end
+							end
+							
+							victim.singleton_class.prepend(pause_during_consume)
+							ready << victim
+							Thread.stop
+							
+							:completed
+						end
+					end
+				rescue Exception => error
+					owner_error = error
+				end
+			end
+			
+			victim = ready.pop
+			Thread.pass until owner.stop?
+			owner.run
+			
+			owner_finishing.pop
+			Thread.pass until owner.stop?
+			
+			canceller = Thread.new do
+				Async do
+					victim.cancel
+				end
+			end
+			
+			expect(canceller.join(1)).to be == canceller
+			owner.run
+			
+			expect(owner.join(1)).to be == owner
+			expect(owner_error).to be_nil
+			expect(victim.status).to be == :completed
+		ensure
+			owner&.run if owner&.alive? && owner&.stop?
+			canceller&.kill
+			owner&.kill
+			canceller&.join
+			owner&.join
+		end
+		
 		it "defers cancellation if the target fiber cannot be raised into directly" do
 			cause = RuntimeError.new("boom")
 			cancelled = []


### PR DESCRIPTION
## Problem

`Task#cancel` currently raises through `Fiber.scheduler`, which is the caller's scheduler rather than necessarily the scheduler that owns the task's fiber.

When cancellation originates from another reactor thread, `Fiber#raise` fails with `FiberError`. The fallback then queues `Cancel::Later` on the caller's scheduler, where it repeatedly retries the same impossible cross-thread raise.

As a result:

- The target task is never cancelled.
- `task.cancel; task.wait` does not complete.
- The caller's reactor busy-spins, repeatedly allocating exceptions and `Cancel::Later` operations.

In the reproduction, this caused roughly 150,000 failed raises over three seconds.

Cross-thread cancellation must also remain on the owning thread during task finalization. `Task#finish!` clears `@fiber` before removing the task from its parent's child list. If handoff depends on `@fiber&.alive?`, a foreign canceller can observe the cleared fiber and run `cancel!`/`finish!` concurrently with the owner, causing a double removal and task-tree corruption.

## Fix

While a task remains attached to another scheduler, enqueue `Cancel::Later` on that scheduler through its thread-safe `unblock` path, regardless of the current value of `@fiber`.

The owning reactor is woken and performs the complete existing cancellation operation on the correct thread. This serializes promise, child-tree, and finalization mutations with the task owner, preserves `defer_cancel` behavior and cancellation causes, and leaves same-reactor cancellation unchanged.

## Testing

Added regression coverage for both cases:

- A separate reactor thread cancels and waits for a task, verifying both reactors terminate, the target is cancelled, its `ensure` block executes, and the original cause is preserved.
- A deterministic finalization interleaving pauses the owner after `@fiber` is cleared, cancels from another thread, and verifies there is no double finalization and the completed result is preserved.

Additional local verification on Ruby 4.0.6:

- 540 tests, 1,198 assertions.
- 147 RuboCop files, no offenses.
- 500 finalization-race runs and 200 original reproducer runs without a crash or failure.
