### PR TITLE
Retry interrupted waits in io_wait and process_wait

### DIFF
--- a/async.gemspec
+++ b/async.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
 	
 	spec.add_dependency "console", "~> 1.29"
 	spec.add_dependency "fiber-annotation"
-	spec.add_dependency "io-event", "~> 1.11"
+	spec.add_dependency "io-event", "~> 1.21"
 end

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -426,7 +426,7 @@ module Async
 			while true
 				status = @selector.process_wait(fiber, pid, flags)
 				
-				# `false` indicates the wake-up was spurious, e.g. a stale {unblock}:
+				# `false` indicates the process wait was interrupted before completion:
 				return status unless status == false
 			end
 		end

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -324,9 +324,7 @@ module Async
 				end
 			end
 			
-			# A selector wait may return a falsy result when the fiber is resumed without the requested IO becoming ready.
-			# For example, a deferred unblock from a previous blocking operation may arrive after the fiber has moved on to this wait.
-			# Retry these stale or spurious wake-ups without resetting the original timer.
+			# A selector wait may return a falsy result when the fiber is resumed without the requested IO becoming ready. For example, a deferred unblock from a previous blocking operation may arrive after the fiber has moved on to this wait. Retry these stale or spurious wake-ups without resetting the original timer.
 			until result = @selector.io_wait(fiber, io, events)
 				# If the original timer resumed the fiber, the falsy result represents the timeout rather than a spurious wake-up:
 				return nil if expired
@@ -427,9 +425,7 @@ module Async
 		def process_wait(pid, flags)
 			fiber = Fiber.current
 			
-			# A native process wait may be interrupted before the child exits.
-			# io-event reports this as `false` and leaves the retry policy to the scheduler.
-			# Retry only `false`, since `nil` is a legitimate result for `Process::WNOHANG`.
+			# A native process wait may be interrupted before the child exits. io-event reports this as `false` and leaves the retry policy to the scheduler. Retry only `false`, since `nil` is a legitimate result for `Process::WNOHANG`.
 			while true
 				status = @selector.process_wait(fiber, pid, flags)
 				

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -426,8 +426,12 @@ module Async
 			while true
 				status = @selector.process_wait(fiber, pid, flags)
 				
-				# `false` indicates the wake-up was spurious, e.g. a stale {unblock}
-				return status unless status == false
+				# Native selectors return `false` after a spurious wake-up. Thread-backed waits may return `nil`, but `nil` is also the expected result for a non-blocking wait:
+				if status.nil?
+					return nil unless (flags & ::Process::WNOHANG).zero?
+				elsif status != false
+					return status
+				end
 			end
 		end
 		

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -426,12 +426,8 @@ module Async
 			while true
 				status = @selector.process_wait(fiber, pid, flags)
 				
-				# Native selectors return `false` after a spurious wake-up. Thread-backed waits may return `nil`, but `nil` is also the expected result for a non-blocking wait:
-				if status.nil?
-					return nil unless (flags & ::Process::WNOHANG).zero?
-				elsif status != false
-					return status
-				end
+				# `false` indicates the wake-up was spurious, e.g. a stale {unblock}:
+				return status unless status == false
 			end
 		end
 		

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -324,7 +324,11 @@ module Async
 				end
 			end
 			
+			# A selector wait may return a falsy result when the fiber is resumed without the requested IO becoming ready.
+			# For example, a deferred unblock from a previous blocking operation may arrive after the fiber has moved on to this wait.
+			# Retry these stale or spurious wake-ups without resetting the original timer.
 			until result = @selector.io_wait(fiber, io, events)
+				# If the original timer resumed the fiber, the falsy result represents the timeout rather than a spurious wake-up:
 				return nil if expired
 			end
 			
@@ -423,10 +427,12 @@ module Async
 		def process_wait(pid, flags)
 			fiber = Fiber.current
 			
+			# A native process wait may be interrupted before the child exits.
+			# io-event reports this as `false` and leaves the retry policy to the scheduler.
+			# Retry only `false`, since `nil` is a legitimate result for `Process::WNOHANG`.
 			while true
 				status = @selector.process_wait(fiber, pid, flags)
 				
-				# `false` indicates the process wait was interrupted before completion:
 				return status unless status == false
 			end
 		end

--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -309,10 +309,12 @@ module Async
 		# @parameter timeout [Float | Nil] The maximum time to wait, or if nil, indefinitely.
 		def io_wait(io, events, timeout = nil)
 			fiber = Fiber.current
+			expired = false
 			
 			if timeout
 				# If an explicit timeout is specified, we expect that the user will handle it themselves:
 				timer = @timers.after(timeout) do
+					expired = true
 					fiber.transfer
 				end
 			elsif timeout = io.timeout
@@ -322,7 +324,11 @@ module Async
 				end
 			end
 			
-			return @selector.io_wait(fiber, io, events)
+			until result = @selector.io_wait(fiber, io, events)
+				return nil if expired
+			end
+			
+			return result
 		ensure
 			timer&.cancel!
 		end
@@ -415,7 +421,14 @@ module Async
 		# @returns [Process::Status] A process status instance.
 		# @asynchronous May be non-blocking..
 		def process_wait(pid, flags)
-			return @selector.process_wait(Fiber.current, pid, flags)
+			fiber = Fiber.current
+			
+			while true
+				status = @selector.process_wait(fiber, pid, flags)
+				
+				# `false` indicates the wake-up was spurious, e.g. a stale {unblock}
+				return status unless status == false
+			end
 		end
 		
 		# Wait for the specified IOs to become ready for the specified events.

--- a/releases.md
+++ b/releases.md
@@ -3,7 +3,6 @@
 ## Unreleased
 
   - Fixed scheduler I/O and process waits returning prematurely after stale or interrupted wake-ups. I/O waits now preserve their original timeout, while blocking process waits retry and non-blocking `Process::WNOHANG` waits still return `nil`.
-  - Require `io-event` v1.21 or later for consistent interrupted process wait handling across selector backends.
 
 ## v2.44.0
 

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,10 @@
 # Releases
 
+## Unreleased
+
+  - Fixed scheduler I/O and process waits returning prematurely after stale or interrupted wake-ups. I/O waits now preserve their original timeout, while blocking process waits retry and non-blocking `Process::WNOHANG` waits still return `nil`.
+  - Require `io-event` v1.21 or later for consistent interrupted process wait handling across selector backends.
+
 ## v2.44.0
 
   - Fixed scheduler cleanup after forking while other fibers are blocked.

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -269,6 +269,32 @@ describe Async::Scheduler do
 	end
 	
 	with "#process_wait" do
+		it "retries spurious nil results from blocking waits" do
+			status = Object.new
+			results = [nil, status]
+			selector = Object.new
+			
+			selector.define_singleton_method(:process_wait) do |fiber, pid, flags|
+				results.shift
+			end
+			
+			scheduler = Async::Scheduler.new(selector: selector)
+			
+			expect(scheduler.process_wait(123, 0)).to be_equal(status)
+		end
+		
+		it "returns nil from non-blocking waits" do
+			selector = Object.new
+			
+			selector.define_singleton_method(:process_wait) do |fiber, pid, flags|
+				nil
+			end
+			
+			scheduler = Async::Scheduler.new(selector: selector)
+			
+			expect(scheduler.process_wait(123, Process::WNOHANG)).to be_nil
+		end
+		
 		it "ignores stale wake-ups from previous blocking operations" do
 			input, output = IO.pipe
 			pid = Process.spawn(RbConfig.ruby, "-e", "STDIN.read", in: input)

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -269,6 +269,46 @@ describe Async::Scheduler do
 	end
 	
 	with "#block" do
+		it "ignores stale wake-ups from previous blocking operations" do
+			input, output = IO.pipe
+			duration = nil
+			
+			Sync do |parent|
+				queue = Thread::Queue.new
+				
+				child = parent.async do |task|
+					begin
+						task.with_timeout(0.02) do
+							queue.pop
+						end
+					rescue Async::TimeoutError
+						# Expected - the item was pushed after the timeout already expired.
+					end
+					
+					# The deferred wake-up from `queue.push` must not spuriously interrupt a subsequent IO operation:
+					duration = Async::Clock.measure do
+						input.wait_readable(0.02)
+					end
+				end
+				
+				producer = parent.async do
+					sleep(0.01)
+					queue.push(:wakeup)
+				end
+				
+				# Prevent the event loop from running until both the producer's sleep and the child's timeout are overdue, so that the wake-up from `queue.push` is still pending when the timeout fires:
+				Fiber.blocking{sleep(0.03)}
+				
+				child.wait
+				producer.wait
+			end
+			
+			expect(duration).to be >= 0.02
+		ensure
+			input&.close
+			output&.close
+		end
+		
 		it "can block and unblock the scheduler after closing" do
 			scheduler = Async::Scheduler.new
 			

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -269,7 +269,7 @@ describe Async::Scheduler do
 	end
 	
 	with "#process_wait" do
-		it "retries spurious false results from blocking waits" do
+		it "retries interrupted process waits" do
 			status = Object.new
 			results = [false, status]
 			selector = Object.new

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -268,6 +268,68 @@ describe Async::Scheduler do
 		end
 	end
 	
+	with "#process_wait" do
+		it "ignores stale wake-ups from previous blocking operations" do
+			input, output = IO.pipe
+			pid = Process.spawn(RbConfig.ruby, "-e", "STDIN.read", in: input)
+			input.close
+			input = nil
+			status = nil
+			
+			Sync do |parent|
+				queue = Thread::Queue.new
+				
+				child = parent.async do |task|
+					begin
+						task.with_timeout(0.02) do
+							queue.pop
+						end
+					rescue Async::TimeoutError
+						# Expected - the item was pushed after the timeout already expired.
+					end
+					
+					# The deferred wake-up from `queue.push` must not spuriously interrupt the process wait:
+					_, status = Process.wait2(pid)
+				end
+				
+				producer = parent.async do
+					sleep(0.01)
+					queue.push(:wakeup)
+					
+					# Release the child process after the stale wake-up has been delivered:
+					sleep(0.01)
+					output.close
+					output = nil
+				end
+				
+				# Prevent the event loop from running until both the producer's sleep and the child's timeout are overdue, so that the wake-up from `queue.push` is still pending when the timeout fires:
+				Fiber.blocking{sleep(0.03)}
+				
+				child.wait
+				producer.wait
+			end
+			
+			expect(status).to be(:success?)
+		ensure
+			input&.close
+			output&.close
+			
+			if pid
+				begin
+					Process.kill(:KILL, pid)
+				rescue Errno::ESRCH
+					# The process already exited.
+				end
+				
+				begin
+					Process.wait(pid)
+				rescue Errno::ECHILD
+					# The process was already reaped.
+				end
+			end
+		end
+	end
+	
 	with "#block" do
 		it "ignores stale wake-ups from previous blocking operations" do
 			input, output = IO.pipe

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -301,6 +301,7 @@ describe Async::Scheduler do
 		it "ignores stale wake-ups from previous blocking operations" do
 			input, output = IO.pipe
 			duration = nil
+			result = nil
 			
 			Sync do |parent|
 				queue = Thread::Queue.new
@@ -316,7 +317,7 @@ describe Async::Scheduler do
 					
 					# The deferred wake-up from `queue.push` must not spuriously interrupt a subsequent IO operation:
 					duration = Async::Clock.measure do
-						input.wait_readable(0.02)
+						result = input.wait_readable(0.02)
 					end
 				end
 				
@@ -332,6 +333,7 @@ describe Async::Scheduler do
 				producer.wait
 			end
 			
+			expect(result).to be_nil
 			expect(duration).to be >= 0.02
 		ensure
 			input&.close

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -283,20 +283,6 @@ describe Async::Scheduler do
 			expect(scheduler.process_wait(123, 0)).to be_equal(status)
 		end
 		
-		it "retries spurious nil results from blocking waits" do
-			status = Object.new
-			results = [nil, status]
-			selector = Object.new
-			
-			selector.define_singleton_method(:process_wait) do |fiber, pid, flags|
-				results.shift
-			end
-			
-			scheduler = Async::Scheduler.new(selector: selector)
-			
-			expect(scheduler.process_wait(123, 0)).to be_equal(status)
-		end
-		
 		it "returns nil from non-blocking waits" do
 			selector = Object.new
 			

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -269,6 +269,20 @@ describe Async::Scheduler do
 	end
 	
 	with "#process_wait" do
+		it "retries spurious false results from blocking waits" do
+			status = Object.new
+			results = [false, status]
+			selector = Object.new
+			
+			selector.define_singleton_method(:process_wait) do |fiber, pid, flags|
+				results.shift
+			end
+			
+			scheduler = Async::Scheduler.new(selector: selector)
+			
+			expect(scheduler.process_wait(123, 0)).to be_equal(status)
+		end
+		
 		it "retries spurious nil results from blocking waits" do
 			status = Object.new
 			results = [nil, status]
@@ -295,65 +309,6 @@ describe Async::Scheduler do
 			expect(scheduler.process_wait(123, Process::WNOHANG)).to be_nil
 		end
 		
-		it "ignores stale wake-ups from previous blocking operations" do
-			input, output = IO.pipe
-			pid = Process.spawn(RbConfig.ruby, "-e", "STDIN.read", in: input)
-			input.close
-			input = nil
-			status = nil
-			
-			Sync do |parent|
-				queue = Thread::Queue.new
-				
-				child = parent.async do |task|
-					begin
-						task.with_timeout(0.02) do
-							queue.pop
-						end
-					rescue Async::TimeoutError
-						# Expected - the item was pushed after the timeout already expired.
-					end
-					
-					# The deferred wake-up from `queue.push` must not spuriously interrupt the process wait:
-					_, status = Process.wait2(pid)
-				end
-				
-				producer = parent.async do
-					sleep(0.01)
-					queue.push(:wakeup)
-					
-					# Release the child process after the stale wake-up has been delivered:
-					sleep(0.01)
-					output.close
-					output = nil
-				end
-				
-				# Prevent the event loop from running until both the producer's sleep and the child's timeout are overdue, so that the wake-up from `queue.push` is still pending when the timeout fires:
-				Fiber.blocking{sleep(0.03)}
-				
-				child.wait
-				producer.wait
-			end
-			
-			expect(status).to be(:success?)
-		ensure
-			input&.close
-			output&.close
-			
-			if pid
-				begin
-					Process.kill(:KILL, pid)
-				rescue Errno::ESRCH
-					# The process already exited.
-				end
-				
-				begin
-					Process.wait(pid)
-				rescue Errno::ECHILD
-					# The process was already reaped.
-				end
-			end
-		end
 	end
 	
 	with "#block" do


### PR DESCRIPTION
Fixes: https://github.com/socketry/async/issues/467

## Summary

- Retry `io_wait` after a stale selector wake-up while preserving the original timeout.
- Retry `process_wait` when the selector returns `false`, indicating that the native wait was interrupted before process completion.
- Preserve `nil` from `process_wait`, including legitimate `Process::WNOHANG` results.
- Require io-event `~> 1.21`, which provides consistent interrupted-process-wait behavior across native backends.
- Add backend-independent regression coverage for Async's retry policy.

## Scope

io-event owns the native interruption and cancellation contract; Async owns the higher-level retry policy. socketry/io-event#215 fixed modern io_uring cancellation and was released in io-event v1.21.0.

The separate threaded process-wait behavior is not worked around here. socketry/io-event#212 adds test-only coverage on Ruby 4.0 and newer. Ruby 3.3 and 3.4 remain skipped there pending the CRuby backports:

- ruby/ruby#18502 for Ruby 3.3
- ruby/ruby#18503 for Ruby 3.4

## Testing

- `BUNDLE_MIRROR__RUBYGEMS__ORG=https://rubygems.org BUNDLE_GEMFILE=gems.rb bundle exec bake test`
- 541 tests passed with 1,193 assertions on Ruby 4.0.6 using io-event 1.21.0.
- CI passes across CRuby, selector backends, worker-pool coverage, lint, documentation, CodeQL, and external tests.
- The JRuby timeout cascade and TruffleRuby `Fiber.set_scheduler` failure reproduce identically on the previous commit (`57ffab4`) and are unrelated to this update.

## Types of Changes

- Bug fix.

## Contribution

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

