### PR TITLE
Fix URing backend probe on Ruby head

### DIFF
--- a/.github/workflows/test-uring.yaml
+++ b/.github/workflows/test-uring.yaml
@@ -39,7 +39,7 @@ jobs:
         cache-version: uring
     
     - name: Backends
-      run: bundle exec ruby -r"io/event" -e "puts IO::Event::Selector.constants"
+      run: bundle exec ruby -e 'require "io/event"; puts IO::Event::Selector.constants'
     
     - name: Run tests
       timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Load `io/event` from the evaluated Ruby script, after Bundler has initialized the bundle.
- Keep the URing backend probe working on Ruby head.

## Background

Ruby head currently processes command-line `-r` options before the `RUBYOPT` entry installed by `bundle exec` for `bundler/setup`. As a result, the existing probe tries to load the bundle-only `io-event` gem too early and fails with `LoadError`.

This was observed in https://github.com/socketry/async/actions/runs/32923544003/job/98041735408?pr=469.

## Verification

- Parsed `.github/workflows/test-uring.yaml` successfully.
- Reproduced against Ruby `4.1.0dev` at `abc5a924d9`: the old command exits 1 with `LoadError`; the updated command exits 0 and lists the available selectors.
- Ran the updated command successfully in the local bundle.
