### PR TITLE
Fix buffered IO signatures for Ruby 4.1

### DIFF
--- a/lib/async/scheduler.rb
+++ b/lib/async/scheduler.rb
@@ -336,16 +336,16 @@ module Async
 		end
 		
 		if ::IO::Event::Support.buffer?
-			# Read from the specified IO into the buffer.
+			# Read at most the specified number of bytes from the IO into the buffer.
 			#
 			# @public Since *Async v2* and Ruby with `IO::Buffer` support.
 			# @asynchronous May be non-blocking.
 			#
 			# @parameter io [IO] The IO object to read from.
 			# @parameter buffer [IO::Buffer] The buffer to read into.
-			# @parameter length [Integer] The minimum number of bytes to read.
 			# @parameter offset [Integer] The offset within the buffer to read into.
-			def io_read(io, buffer, length, offset = 0)
+			# @parameter length [Integer] The maximum number of bytes to read.
+			def io_read(io, buffer, offset, length)
 				fiber = Fiber.current
 				
 				if timeout = io.timeout
@@ -354,22 +354,22 @@ module Async
 					end
 				end
 				
-				@selector.io_read(fiber, io, buffer, length, offset)
+				@selector.io_read(fiber, io, buffer, offset, length)
 			ensure
 				timer&.cancel!
 			end
 			
 			if RUBY_ENGINE != "ruby" || RUBY_VERSION >= "3.3.1"
-				# Write the specified buffer to the IO.
+				# Write at most the specified number of bytes from the buffer to the IO.
 				#
 				# @public Since *Async v2* and *Ruby v3.3.1* with `IO::Buffer` support.
 				# @asynchronous May be non-blocking.
 				#
 				# @parameter io [IO] The IO object to write to.
 				# @parameter buffer [IO::Buffer] The buffer to write from.
-				# @parameter length [Integer] The minimum number of bytes to write.
 				# @parameter offset [Integer] The offset within the buffer to write from.
-				def io_write(io, buffer, length, offset = 0)
+				# @parameter length [Integer] The maximum number of bytes to write.
+				def io_write(io, buffer, offset, length)
 					fiber = Fiber.current
 					
 					if timeout = io.timeout
@@ -378,7 +378,7 @@ module Async
 						end
 					end
 					
-					@selector.io_write(fiber, io, buffer, length, offset)
+					@selector.io_write(fiber, io, buffer, offset, length)
 				ensure
 					timer&.cancel!
 				end

--- a/test/async/scheduler.rb
+++ b/test/async/scheduler.rb
@@ -125,7 +125,11 @@ describe Async::Scheduler do
 				scheduler.instance_variable_set(:@selector, selector)
 				
 				expect do
-					scheduler.io_read(io, IO::Buffer.new(1024), 1024)
+					if defined?(IO::Buffer::VERSION) && IO::Buffer::VERSION >= 3
+						scheduler.io_read(io, IO::Buffer.new(1024), 0, 1024)
+					else
+						scheduler.io_read(io, IO::Buffer.new(1024), 1024, 0)
+					end
 				end.to raise_exception(::IO::TimeoutError)
 			ensure
 				scheduler&.close


### PR DESCRIPTION
## Summary

- adopt the Ruby 4.1 `io_read(io, buffer, offset, length)` and `io_write(io, buffer, offset, length)` public signatures directly
- document `length` as the maximum transfer size
- keep timeout handling and positional delegation to `io-event` unchanged
- adjust the existing timeout test invocation for the active runtime contract

Async does not need separate method definitions for the old and new interfaces. CRuby 3.3 and 3.4 also invoke these scheduler hooks with four positional arguments, while `io-event` already interprets the forwarded pair according to the active scheduler interface version.

## References

- https://github.com/ruby/ruby/pull/18483
- https://github.com/socketry/io-event/pull/211

## Testing

- `bundle exec rubocop lib/async/scheduler.rb test/async/scheduler.rb`
- `bundle exec sus test/async/scheduler.rb` — 18 examples, 39 assertions
- `bundle exec bake test` — 541 examples, 1,193 assertions
